### PR TITLE
Adds support for CSS Custom Properties in @tidy rules

### DIFF
--- a/Grid.js
+++ b/Grid.js
@@ -87,10 +87,6 @@ class Grid {
   getEdges() {
     const { edge } = this.options;
 
-    if (varPattern.test(edge)) {
-      return `${edge} * 2`;
-    }
-
     return (undefined === edge) ? 0 : `${edge} * 2`;
   }
 

--- a/Grid.js
+++ b/Grid.js
@@ -1,3 +1,5 @@
+const { varPattern } = require('./lib/normalize-options');
+
 /**
  * Grid class
  * Calculate column and offset values based on processed options.
@@ -64,6 +66,10 @@ class Grid {
   getSharedGap() {
     const { gap, columns } = this.options;
 
+    if (varPattern.test(gap)) {
+      return `(${gap} / ${columns} * (${columns} - 1))`;
+    }
+
     if (undefined !== gap) {
       const [value, units] = this.constructor.splitCssUnit(gap);
       const sharedGap = (value / columns) * (columns - 1);
@@ -79,7 +85,13 @@ class Grid {
    * @returns {String|Number}
    */
   getEdges() {
-    return (undefined === this.options.edge) ? 0 : `${this.options.edge} * 2`;
+    const { edge } = this.options;
+
+    if (varPattern.test(edge)) {
+      return `${edge} * 2`;
+    }
+
+    return (undefined === edge) ? 0 : `${edge} * 2`;
   }
 
   /**

--- a/Grid.js
+++ b/Grid.js
@@ -68,11 +68,10 @@ class Grid {
 
     if (varPattern.test(gap)) {
       return `(${gap} / ${columns} * (${columns} - 1))`;
-    }
-
-    if (undefined !== gap) {
+    } else if (undefined !== gap) {
       const [value, units] = this.constructor.splitCssUnit(gap);
       const sharedGap = (value / columns) * (columns - 1);
+
       return `${this.constructor.roundToPrecision(sharedGap, 4)}${units}`;
     }
 

--- a/README.md
+++ b/README.md
@@ -350,6 +350,39 @@ Local options are defined via `@tidy` rules inside a selector block
 and are scoped to the parent selector. Values declared here take precedence over 
 the global options.
 
+### Using CSS Custom Properties in setting values
+
+[CSS Custom Proprties](https://developer.mozilla.org/en-US/docs/Web/CSS/--*) are 
+supported in `@tidy` rules, with the following caveats:
+
+1. Due to the nature of CSS Custom Properties, particularly the inability to use
+them in media query parmeters, a CSS Custom Property used as the `@tidy site-max`
+value will throw an error.
+2. The `@tidy gap` custom property value must only contain its length and not its
+`/ <boolean>` portion of the [gap shorthand](#addgap).
+
+Example:
+
+```css
+:root {
+	--columns: 16;
+	--gap: 0.625rem;
+	--edge: 1.25;
+}
+
+@media (min-width: 75rem) {
+	:root {
+		--gap: 1rem;
+		--edge: 2rem;
+	}
+}
+
+@tidy columns var(--columns);
+@tidy gap var(--gap) / true;
+@tidy edge var(--edge);
+@tidy site-max 75rem;
+```
+
 <!-- links -->
 [PostCSS]: https://github.com/postcss/postcss
 [ci-img]:  https://travis-ci.com/goodguyry/postcss-tidy-columns.svg?branch=master

--- a/index.js
+++ b/index.js
@@ -39,6 +39,7 @@ module.exports = postcss.plugin('postcss-tidy-columns', (options = {}) => {
 
       // Add the media query if a siteMax is declared and the `fullWidthRule` has children.
       if (undefined !== siteMax && fullWidthRule.nodes.length > 0) {
+        // TODO: Detect and handle `siteMax` custom property value for the media query param
         /**
          * The siteMax-width atRule.
          * Contains full-width margin offset declarations.

--- a/index.js
+++ b/index.js
@@ -39,7 +39,6 @@ module.exports = postcss.plugin('postcss-tidy-columns', (options = {}) => {
 
       // Add the media query if a siteMax is declared and the `fullWidthRule` has children.
       if (undefined !== siteMax && fullWidthRule.nodes.length > 0) {
-        // TODO: Detect and handle `siteMax` custom property value for the media query param
         /**
          * The siteMax-width atRule.
          * Contains full-width margin offset declarations.

--- a/lib/normalize-options.js
+++ b/lib/normalize-options.js
@@ -1,3 +1,5 @@
+const varPattern = /^var\(--[\w-]+\)/;
+
 /**
  * Normalize option value types.
  * Since CSS values are always strings, we need to do some type checking.
@@ -6,7 +8,7 @@
  *
  * @returns {Object}
  */
-module.exports = function normalizeOptions(options) {
+function normalizeOptions(options) {
   const LENGTH_REGEX = /^[0-9.]+(px|r?em)+$/;
 
   const validateOptions = Object.keys(options)
@@ -15,6 +17,11 @@ module.exports = function normalizeOptions(options) {
 
       // These will be filtered out later.
       if ('inherit' === option || undefined === option) {
+        return acc;
+      }
+
+      if (varPattern.test(option)) {
+        acc[key] = option;
         return acc;
       }
 
@@ -38,4 +45,9 @@ module.exports = function normalizeOptions(options) {
     }, {});
 
   return validateOptions;
+}
+
+module.exports = {
+  normalizeOptions,
+  varPattern,
 };

--- a/lib/normalize-options.js
+++ b/lib/normalize-options.js
@@ -21,24 +21,24 @@ function normalizeOptions(options) {
       }
 
       if (varPattern.test(option)) {
+        // Use the raw option value if it's a var() function.
         acc[key] = option;
-        return acc;
-      }
+      } else {
+        // `columns` should be a number.
+        if ('columns' === key && !Number.isNaN(Number(option))) {
+          acc[key] = Number(option);
+        }
 
-      // `columns` should be a number.
-      if ('columns' === key && !Number.isNaN(Number(option))) {
-        acc[key] = Number(option);
-      }
+        // `addGap` should be Boolean.
+        if ('addGap' === key) {
+          acc[key] = ('true' === String(option));
+        }
 
-      // `addGap` should be Boolean.
-      if ('addGap' === key) {
-        acc[key] = ('true' === String(option));
-      }
-
-      // These should all be valid, positive CSS length values.
-      if (['gap', 'edge', 'siteMax'].includes(key) && LENGTH_REGEX.test(option)) {
-        // Force `undefined` in place of `0`.
-        acc[key] = 0 === Number(option) ? undefined : option;
+        // These should all be valid, positive CSS length values.
+        if (['gap', 'edge', 'siteMax'].includes(key) && LENGTH_REGEX.test(option)) {
+          // Force `undefined` in place of `0`.
+          acc[key] = 0 === Number(option) ? undefined : option;
+        }
       }
 
       return acc;

--- a/lib/normalize-options.js
+++ b/lib/normalize-options.js
@@ -1,4 +1,4 @@
-const varPattern = /^var\(--[\w-]+\)/;
+const varPattern = /var\((--[\w-]+)\)/;
 
 /**
  * Normalize option value types.

--- a/lib/parse-options.js
+++ b/lib/parse-options.js
@@ -1,6 +1,17 @@
 const { normalizeOptions } = require('./normalize-options');
 
 /**
+ * Camelcase the hyphenated property names.
+ * `siteMax` can be passed as `site-max` in CSS because it's more "CSS-like".
+ *
+ * @param {string} property A property name to camelcase.
+ */
+function camelCaseProperty(property) {
+  return property.split('-').map((word, i) =>
+    ((i !== 0) ? word.charAt(0).toUpperCase() + word.slice(1) : word)).join('');
+}
+
+/**
  * Parse and compile CSS @tidy at-rule parameters.
  *
  * @param {Array} optionsArray An array of at-rule params.
@@ -13,23 +24,15 @@ function parseOptions(optionsArray) {
      * property: The option name.
      * value:    The option value.
      */
-    const [property, value] = setting.match(/^(\S+)\s(.*)/).slice(1);
+    const [prop, value] = setting.match(/^(\S+)\s(.*)/).slice(1);
+    const property = camelCaseProperty(prop);
 
-    if ('site-max' === property) {
-      /*
-       * Camelcase the property name.
-       * `siteMax` can be passed as `site-max` in CSS because it's a more "CSS-like" property.
-       */
-      const newProperty = property.split('-').map((word, i) =>
-        ((i !== 0) ? word.charAt(0).toUpperCase() + word.slice(1) : word)).join('');
-
-      acc[newProperty] = value.trim();
-    } else if ('gap' === property) {
+    if ('gap' === property) {
       // Split the `gap` and `addGap`.
       const [gap, addGap] = value.split('/');
 
       acc[property] = gap.trim();
-      // This is either `underfined` or a String.
+      // This is either `undefined` or a string.
       acc.addGap = undefined === addGap ? undefined : addGap.trim();
     } else {
       acc[property] = value.trim();

--- a/lib/parse-options.js
+++ b/lib/parse-options.js
@@ -1,4 +1,4 @@
-const { normalizeOptions } = require('./normalize-options');
+const { normalizeOptions, varPattern } = require('./normalize-options');
 
 /**
  * Camelcase the hyphenated property names.
@@ -9,6 +9,29 @@ const { normalizeOptions } = require('./normalize-options');
 function camelCaseProperty(property) {
   return property.split('-').map((word, i) =>
     ((i !== 0) ? word.charAt(0).toUpperCase() + word.slice(1) : word)).join('');
+}
+
+/**
+ * Get a CSS Custom Property's real value.
+ *
+ * @param {object} root The CSS root.
+ * @param {string} params The raw option value.
+ */
+function getCustomPropertyValue(root, params) {
+  const [prop, value] = params.match(/^(\S+)\s(.*)/).slice(1);
+  const [, customProp] = value.match(varPattern);
+
+  let declValue = '';
+  // Find custom property real value.
+  root.walkDecls(`${customProp}`, (decl) => {
+    if (':root' === decl.parent.selector) {
+      declValue = decl.value;
+    }
+  });
+
+  // TODO: Print warning if not found.
+  // Rebuild param string.
+  return ('' !== declValue ? `${prop} ${declValue}` : params);
 }
 
 /**
@@ -69,7 +92,14 @@ function getGlobalOptions(root, options) {
   const atRuleParams = [];
   root.walkAtRules('tidy', (atrule) => {
     if ('root' === atrule.parent.type) {
-      atRuleParams.push(atrule.params);
+      const { params } = atrule;
+      // Find site-max real value if a custom property.
+      if (varPattern.test(params) && /site-?max/i.test(params)) {
+        const newParams = getCustomPropertyValue(root, params);
+        atRuleParams.push(newParams);
+      } else {
+        atRuleParams.push(params);
+      }
       atrule.remove();
     }
   });

--- a/lib/parse-options.js
+++ b/lib/parse-options.js
@@ -29,6 +29,33 @@ function handleCustomProperties(rule, params) {
 }
 
 /**
+ * Collect @tidy params from the provided CSS root.
+ *
+ * @param {Object} css The CSS root/rule.
+ * @param {Boolean} equals Use `===` or `!==` as the `if` statement's condition.
+ * @returns
+ */
+function collectTidyRuleParams(css, equals) {
+  // Collect CSS at-rule values.
+  const atRuleParams = [];
+
+  css.walkAtRules('tidy', (atrule) => {
+    const { params, parent: { type: parentType } } = atrule;
+    if (equals ? 'root' === parentType : 'root' !== parentType) {
+      // Reject `site-max` with CSS Custom Property.
+      if (varPattern.test(params)) {
+        handleCustomProperties(atrule, params);
+      }
+
+      atRuleParams.push(params);
+      atrule.remove();
+    }
+  });
+
+  return atRuleParams;
+}
+
+/**
  * Parse and compile CSS @tidy at-rule parameters.
  *
  * @param {Array} optionsArray An array of at-rule params.
@@ -82,21 +109,8 @@ function getGlobalOptions(root, options) {
   // Normalize plugin options.
   const pluginOptions = normalizeOptions(options);
 
-  // Collect CSS at-rule values.
-  const atRuleParams = [];
-  root.walkAtRules('tidy', (atrule) => {
-    if ('root' === atrule.parent.type) {
-      const { params } = atrule;
-
-      // Reject `site-max` with CSS Custom Property.
-      if (varPattern.test(params)) {
-        handleCustomProperties(atrule, params);
-      }
-
-      atRuleParams.push(params);
-      atrule.remove();
-    }
-  });
+  // Collect root at-rule values.
+  const atRuleParams = collectTidyRuleParams(root, true);
 
   // Parse the CSS option values.
   const atRuleOpts = parseOptions(atRuleParams);
@@ -113,14 +127,8 @@ function getGlobalOptions(root, options) {
  * @returns {Object} The merged local options.
  */
 function getLocalOptions(rule, global) {
-  // Collect CSS at-rule values.
-  const atRuleParams = [];
-  rule.walkAtRules('tidy', (atrule) => {
-    if ('root' !== atrule.parent.type) {
-      atRuleParams.push(atrule.params);
-      atrule.remove();
-    }
-  });
+  // Collect this rule's at-rule values.
+  const atRuleParams = collectTidyRuleParams(rule, false);
 
   // Parse the rule's CSS option values.
   const atRuleOpts = parseOptions(atRuleParams);

--- a/lib/parse-options.js
+++ b/lib/parse-options.js
@@ -1,4 +1,4 @@
-const normalizeOptions = require('./normalize-options');
+const { normalizeOptions } = require('./normalize-options');
 
 /**
  * Parse and compile CSS @tidy at-rule parameters.

--- a/lib/parse-options.js
+++ b/lib/parse-options.js
@@ -12,43 +12,20 @@ function camelCaseProperty(property) {
 }
 
 /**
- * Get a CSS Custom Property's real value.
+ * Reject usage of CSS Custom Properties in `@tidy site-max` rules.
  *
- * @param {object} root The CSS root.
- * @param {string} params The raw option value.
+ * This is due to `tidy-offset-*` using `site-max` Media Queries
+ * CSS Custom Properties aren't allowed in Media Query parameters.
+ *
+ * @param {Object} rule The CSS root object.
+ * @param {String} params The `@tidy` rule value.
  */
-function getCustomPropertyValue(root, params) {
-  const [prop, value] = params.match(/^(\S+)\s(.*)/).slice(1);
-  const [, customProp] = value.match(varPattern);
+function handleCustomProperties(rule, params) {
+  const [property] = params.match(/^(\S+)\s(.*)/).slice(1);
 
-  // Collect root-level `:root{}` child declarations matching the custom property.
-  const customPropertyNodes = root.nodes
-    .reduce((acc, node) => {
-      if (
-        'rule' === node.type &&
-        ':root' === node.selector &&
-        'root' === node.parent.type
-      ) {
-        return [...acc, ...node.nodes];
-      }
-      return acc;
-    }, [])
-    .filter(node => customProp === node.prop);
-
-  if (0 === customPropertyNodes.length) {
-    // Throw error if no custom property declaration is found.
-    throw root.error(`Custom property \`${customProp}\` not found.`);
-  } else if (1 < customPropertyNodes.length) {
-    // Throw error more than one site-max custom property declaration is found.
-    throw root.error(`Multiple \`${customProp}\` declarations found. When using a custom property as the ${prop} value, that property cannot be redeclared.`);
+  if (/site-?max/i.test(property)) {
+    throw rule.error(`CSS Custom Property value is not allowed in \`@tidy ${property}\` declaration`);
   }
-
-  // Rebuild param string.
-  return (
-    '' !== customPropertyNodes[0].value ?
-      `${prop} ${customPropertyNodes[0].value}` :
-      params
-  );
 }
 
 /**
@@ -110,13 +87,13 @@ function getGlobalOptions(root, options) {
   root.walkAtRules('tidy', (atrule) => {
     if ('root' === atrule.parent.type) {
       const { params } = atrule;
-      // Find site-max real value if a custom property.
-      if (varPattern.test(params) && /site-?max/i.test(params)) {
-        const newParams = getCustomPropertyValue(root, params);
-        atRuleParams.push(newParams);
-      } else {
-        atRuleParams.push(params);
+
+      // Reject `site-max` with CSS Custom Property.
+      if (varPattern.test(params)) {
+        handleCustomProperties(atrule, params);
       }
+
+      atRuleParams.push(params);
       atrule.remove();
     }
   });

--- a/lib/parse-options.js
+++ b/lib/parse-options.js
@@ -35,8 +35,14 @@ function getCustomPropertyValue(root, params) {
     }, [])
     .filter(node => customProp === node.prop);
 
-  // TODO: Print warning if not found.
-  // TODO: Print warning if more than one found.
+  if (0 === customPropertyNodes.length) {
+    // Throw error if no custom property declaration is found.
+    throw root.error(`Custom property \`${customProp}\` not found.`);
+  } else if (1 < customPropertyNodes.length) {
+    // Throw error more than one site-max custom property declaration is found.
+    throw root.error(`Multiple \`${customProp}\` declarations found. When using a custom property as the ${prop} value, that property cannot be redeclared.`);
+  }
+
   // Rebuild param string.
   return (
     '' !== customPropertyNodes[0].value ?

--- a/lib/parse-options.js
+++ b/lib/parse-options.js
@@ -21,17 +21,28 @@ function getCustomPropertyValue(root, params) {
   const [prop, value] = params.match(/^(\S+)\s(.*)/).slice(1);
   const [, customProp] = value.match(varPattern);
 
-  let declValue = '';
-  // Find custom property real value.
-  root.walkDecls(`${customProp}`, (decl) => {
-    if (':root' === decl.parent.selector) {
-      declValue = decl.value;
-    }
-  });
+  // Collect root-level `:root{}` child declarations matching the custom property.
+  const customPropertyNodes = root.nodes
+    .reduce((acc, node) => {
+      if (
+        'rule' === node.type &&
+        ':root' === node.selector &&
+        'root' === node.parent.type
+      ) {
+        return [...acc, ...node.nodes];
+      }
+      return acc;
+    }, [])
+    .filter(node => customProp === node.prop);
 
   // TODO: Print warning if not found.
+  // TODO: Print warning if more than one found.
   // Rebuild param string.
-  return ('' !== declValue ? `${prop} ${declValue}` : params);
+  return (
+    '' !== customPropertyNodes[0].value ?
+      `${prop} ${customPropertyNodes[0].value}` :
+      params
+  );
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "postcss-tidy-columns",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "PostCSS plugin to manage column and margin alignment.",
   "keywords": [
     "postcss",

--- a/test/fixtures/_fixtures.json
+++ b/test/fixtures/_fixtures.json
@@ -232,9 +232,7 @@
     {
       "description": "custom properties",
       "skip": false,
-      "options": {
-        "custom-properties": true
-      },
+      "options": {},
       "fixtures": {
         "input": "fixtures/custom-properties.css",
         "expected": "fixtures/custom-properties.expected.css"

--- a/test/fixtures/_fixtures.json
+++ b/test/fixtures/_fixtures.json
@@ -230,6 +230,17 @@
       }
     },
     {
+      "description": "custom properties",
+      "skip": false,
+      "options": {
+        "custom-properties": true
+      },
+      "fixtures": {
+        "input": "fixtures/custom-properties.css",
+        "expected": "fixtures/custom-properties.expected.css"
+      }
+    },
+    {
       "description": "test-one: should replace `tidy-` properties.",
       "skip": false,
       "options": {},

--- a/test/fixtures/custom-properties.css
+++ b/test/fixtures/custom-properties.css
@@ -1,0 +1,22 @@
+:root {
+	--columns: 16;
+	--gap: 0.625rem;
+	--edge: 32px;
+	--site-max: 75rem;
+}
+
+@tidy columns var(--columns);
+@tidy gap var(--gap) / true;
+@tidy edge var(--edge);
+@tidy site-max var(--site-max);
+
+div {
+	tidy-span: 3;
+	tidy-offset-left: 2;
+}
+@media (min-width: 60rem) {
+	div {
+		tidy-span: 2;
+		tidy-offset-right: 1;
+	}
+}

--- a/test/fixtures/custom-properties.css
+++ b/test/fixtures/custom-properties.css
@@ -2,13 +2,12 @@
 	--columns: 16;
 	--gap: 0.625rem;
 	--edge: 32px;
-	--site-max: 75rem;
 }
 
 @tidy columns var(--columns);
 @tidy gap var(--gap) / true;
 @tidy edge var(--edge);
-@tidy site-max var(--site-max);
+@tidy site-max 75rem;
 
 div {
 	tidy-span: 3;

--- a/test/fixtures/custom-properties.expected.css
+++ b/test/fixtures/custom-properties.expected.css
@@ -7,27 +7,31 @@
 
 div {
 	width: calc((((100vw - var(--edge) * 2) / var(--columns) - (var(--gap) / var(--columns) * (var(--columns) - 1))) * 3) + var(--gap) * 2);
-	max-width: calc((((var(--site-max) - var(--edge) * 2) / var(--columns) - (var(--gap) / var(--columns) * (var(--columns) - 1))) * 3) + var(--gap) * 2);
+	max-width: calc((((75rem - var(--edge) * 2) / var(--columns) - (var(--gap) / var(--columns) * (var(--columns) - 1))) * 3) + var(--gap) * 2);
 	margin-right: var(--gap);
 	margin-left: calc((((100vw - var(--edge) * 2) / var(--columns) - (var(--gap) / var(--columns) * (var(--columns) - 1))) * 2) + var(--gap) * 2);
 }
+
 div:last-of-type {
 	margin-right: 0;
 }
+
 @media (min-width: 75rem) {
+
 	div {
-		margin-left: calc((((var(--site-max) - var(--edge) * 2) / var(--columns) - (var(--gap) / var(--columns) * (var(--columns) - 1))) * 2) + var(--gap) * 2);
+		margin-left: calc((((75rem - var(--edge) * 2) / var(--columns) - (var(--gap) / var(--columns) * (var(--columns) - 1))) * 2) + var(--gap) * 2);
 	}
 }
 @media (min-width: 60rem) {
 	div {
 		width: calc((((100vw - var(--edge) * 2) / var(--columns) - (var(--gap) / var(--columns) * (var(--columns) - 1))) * 2) + var(--gap));
-		max-width: calc((((var(--site-max) - var(--edge) * 2) / var(--columns) - (var(--gap) / var(--columns) * (var(--columns) - 1))) * 2) + var(--gap));
+		max-width: calc((((75rem - var(--edge) * 2) / var(--columns) - (var(--gap) / var(--columns) * (var(--columns) - 1))) * 2) + var(--gap));
 		margin-right: calc(((100vw - var(--edge) * 2) / var(--columns) - (var(--gap) / var(--columns) * (var(--columns) - 1))) + var(--gap));
 	}
 }
 @media (min-width: 75rem) {
+
 	div {
-		margin-right: calc(((var(--site-max) - var(--edge) * 2) / var(--columns) - (var(--gap) / var(--columns) * (var(--columns) - 1))) + var(--gap));
+		margin-right: calc(((75rem - var(--edge) * 2) / var(--columns) - (var(--gap) / var(--columns) * (var(--columns) - 1))) + var(--gap));
 	}
 }

--- a/test/fixtures/custom-properties.expected.css
+++ b/test/fixtures/custom-properties.expected.css
@@ -6,28 +6,28 @@
 }
 
 div {
-	width: calc((((100vw - var(--edge) * 2) / var(--columns) - (var(--gap) * (var(--columns) - 1)) / var(--columns)) * 3) + var(--gap) * 2);
-	max-width: calc((((var(--site-max) - var(--edge) * 2) / var(--columns) - (var(--gap) * (var(--columns) - 1)) / var(--columns)) * 3) + var(--gap) * 2);
+	width: calc((((100vw - var(--edge) * 2) / var(--columns) - (var(--gap) / var(--columns) * (var(--columns) - 1))) * 3) + var(--gap) * 2);
+	max-width: calc((((var(--site-max) - var(--edge) * 2) / var(--columns) - (var(--gap) / var(--columns) * (var(--columns) - 1))) * 3) + var(--gap) * 2);
 	margin-right: var(--gap);
-	margin-left: calc((((100vw - var(--edge) * 2) / var(--columns) - (var(--gap) * (var(--columns) - 1)) / var(--columns)) * 2) + var(--gap) * 2);
+	margin-left: calc((((100vw - var(--edge) * 2) / var(--columns) - (var(--gap) / var(--columns) * (var(--columns) - 1))) * 2) + var(--gap) * 2);
 }
 div:last-of-type {
 	margin-right: 0;
 }
 @media (min-width: 75rem) {
 	div {
-		margin-left: calc((((var(--site-max) - var(--edge) * 2) / var(--columns) - (var(--gap) * (var(--columns) - 1)) / var(--columns)) * 2) + var(--gap) * 2);
+		margin-left: calc((((var(--site-max) - var(--edge) * 2) / var(--columns) - (var(--gap) / var(--columns) * (var(--columns) - 1))) * 2) + var(--gap) * 2);
 	}
 }
 @media (min-width: 60rem) {
 	div {
-		width: calc((((100vw - var(--edge) * 2) / var(--columns) - (var(--gap) * (var(--columns) - 1)) / var(--columns)) * 2) + var(--gap));
-		max-width: calc((((var(--site-max) - var(--edge) * 2) / var(--columns) - (var(--gap) * (var(--columns) - 1)) / var(--columns)) * 2) + var(--gap));
-		margin-right: calc(((100vw - var(--edge) * 2) / var(--columns) - (var(--gap) * (var(--columns) - 1)) / var(--columns)) + var(--gap));
+		width: calc((((100vw - var(--edge) * 2) / var(--columns) - (var(--gap) / var(--columns) * (var(--columns) - 1))) * 2) + var(--gap));
+		max-width: calc((((var(--site-max) - var(--edge) * 2) / var(--columns) - (var(--gap) / var(--columns) * (var(--columns) - 1))) * 2) + var(--gap));
+		margin-right: calc(((100vw - var(--edge) * 2) / var(--columns) - (var(--gap) / var(--columns) * (var(--columns) - 1))) + var(--gap));
 	}
 }
 @media (min-width: 75rem) {
 	div {
-		margin-right: calc(((var(--site-max) - var(--edge) * 2) / var(--columns) - (var(--gap) * (var(--columns) - 1)) / var(--columns)) + var(--gap));
+		margin-right: calc(((var(--site-max) - var(--edge) * 2) / var(--columns) - (var(--gap) / var(--columns) * (var(--columns) - 1))) + var(--gap));
 	}
 }

--- a/test/fixtures/custom-properties.expected.css
+++ b/test/fixtures/custom-properties.expected.css
@@ -2,7 +2,6 @@
 	--columns: 16;
 	--gap: 0.625rem;
 	--edge: 32px;
-	--site-max: 75rem;
 }
 
 div {

--- a/test/fixtures/custom-properties.expected.css
+++ b/test/fixtures/custom-properties.expected.css
@@ -1,0 +1,33 @@
+:root {
+	--columns: 16;
+	--gap: 0.625rem;
+	--edge: 32px;
+	--site-max: 75rem;
+}
+
+div {
+	width: calc((((100vw - var(--edge) * 2) / var(--columns) - (var(--gap) * (var(--columns) - 1)) / var(--columns)) * 3) + var(--gap) * 2);
+	max-width: calc((((var(--site-max) - var(--edge) * 2) / var(--columns) - (var(--gap) * (var(--columns) - 1)) / var(--columns)) * 3) + var(--gap) * 2);
+	margin-right: var(--gap);
+	margin-left: calc((((100vw - var(--edge) * 2) / var(--columns) - (var(--gap) * (var(--columns) - 1)) / var(--columns)) * 2) + var(--gap) * 2);
+}
+div:last-of-type {
+	margin-right: 0;
+}
+@media (min-width: 75rem) {
+	div {
+		margin-left: calc((((var(--site-max) - var(--edge) * 2) / var(--columns) - (var(--gap) * (var(--columns) - 1)) / var(--columns)) * 2) + var(--gap) * 2);
+	}
+}
+@media (min-width: 60rem) {
+	div {
+		width: calc((((100vw - var(--edge) * 2) / var(--columns) - (var(--gap) * (var(--columns) - 1)) / var(--columns)) * 2) + var(--gap));
+		max-width: calc((((var(--site-max) - var(--edge) * 2) / var(--columns) - (var(--gap) * (var(--columns) - 1)) / var(--columns)) * 2) + var(--gap));
+		margin-right: calc(((100vw - var(--edge) * 2) / var(--columns) - (var(--gap) * (var(--columns) - 1)) / var(--columns)) + var(--gap));
+	}
+}
+@media (min-width: 75rem) {
+	div {
+		margin-right: calc(((var(--site-max) - var(--edge) * 2) / var(--columns) - (var(--gap) * (var(--columns) - 1)) / var(--columns)) + var(--gap));
+	}
+}

--- a/test/normalize-options.test.js
+++ b/test/normalize-options.test.js
@@ -1,4 +1,4 @@
-const normalizeOptions = require('../lib/normalize-options');
+const { normalizeOptions } = require('../lib/normalize-options');
 
 /**
  * Test expected option values after normalization.


### PR DESCRIPTION
Adds initial support for CSS Custom Property values in `@tidy` settings.

```css
:root {
	--columns: 16;
	--gap: 0.625rem;
	--edge: 32px;
	--site-max: 75rem;
}

@tidy columns var(--columns);
@tidy gap var(--gap) / true;
@tidy edge var(--edge);
@tidy site-max var(--site-max);
```