### PR TITLE
Column shorthand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,11 @@
 # Change Log
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## 0.2.2
+* Corrects `tidy-column` shorthand matching and replacement.
+
 ## 0.2.1
-* Removes unused dependency (`object-assign`)
+* Removes unused dependency (`object-assign`).
 
 ## 0.2.0
 * Adds support for CSS Custom Properties in `@tidy` rule values.

--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ module.exports = postcss.plugin('postcss-tidy-columns', (options = {}) => {
       const tidy = new Tidy(rule, globalOptions);
 
       // Replace shorthand declarations with their long-form equivalents.
-      rule.walkDecls(/^tidy-(columns|offset)$/, (declaration) => {
+      rule.walkDecls(/^tidy-(column|offset)$/, (declaration) => {
         tidyShorthandProperty(declaration);
       });
 

--- a/lib/tidy-shorthand-property.js
+++ b/lib/tidy-shorthand-property.js
@@ -39,12 +39,12 @@ module.exports = function tidyShorthandProperty(declaration) {
   const shortHandReplace = [];
 
   /**
-   * Replace `tidy-columns` shorthand, based on delcaration values.
+   * Replace `tidy-column` shorthand, based on delcaration values.
    * - tidy-offset-left
    * - tidy-span
    * - tidy-offset-right
    */
-  if ('tidy-columns' === declaration.prop) {
+  if ('tidy-column' === declaration.prop) {
     const COLUMNS_REGEX = /^([\d.-]+|inherit)\s?(\/\s?span\s[\d.-]+)\s?(\/\s?[\d.-]+)?$/;
     /**
      * {undefined}  The full declaration value.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "postcss-tidy-columns",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "PostCSS plugin to manage column and margin alignment.",
   "keywords": [
     "postcss",

--- a/test/fixtures/_fixtures.json
+++ b/test/fixtures/_fixtures.json
@@ -55,7 +55,7 @@
       }
     },
     {
-      "description": "tidy-columns (offset + span shorthand)",
+      "description": "tidy-column (offset + span shorthand)",
       "skip": false,
       "options": {},
       "fixtures": {
@@ -64,7 +64,7 @@
       }
     },
     {
-      "description": "tidy-columns w/ fractional offset",
+      "description": "tidy-column w/ fractional offset",
       "skip": false,
       "options": {},
       "fixtures": {
@@ -73,7 +73,7 @@
       }
     },
     {
-      "description": "tidy-columns w/ gaps",
+      "description": "tidy-column w/ gaps",
       "skip": false,
       "options": {},
       "fixtures": {
@@ -82,7 +82,7 @@
       }
     },
     {
-      "description": "tidy-columns w/ negative offset",
+      "description": "tidy-column w/ negative offset",
       "skip": false,
       "options": {},
       "fixtures": {
@@ -91,7 +91,7 @@
       }
     },
     {
-      "description": "tidy-columns w/ zero offset",
+      "description": "tidy-column w/ zero offset",
       "skip": false,
       "options": {},
       "fixtures": {
@@ -100,7 +100,7 @@
       }
     },
     {
-      "description": "tidy-columns w/ inherit offset",
+      "description": "tidy-column w/ inherit offset",
       "skip": false,
       "options": {},
       "fixtures": {

--- a/test/fixtures/columns-fraction.css
+++ b/test/fixtures/columns-fraction.css
@@ -3,5 +3,5 @@
 @tidy site-max 90rem;
 
 div {
-	tidy-columns: 0.3333 / span 3;
+	tidy-column: 0.3333 / span 3;
 }

--- a/test/fixtures/columns-gap.css
+++ b/test/fixtures/columns-gap.css
@@ -3,5 +3,5 @@
 @tidy site-max 90rem;
 
 div {
-	tidy-columns: 2 / span 3;
+	tidy-column: 2 / span 3;
 }

--- a/test/fixtures/columns-inherit-offset.css
+++ b/test/fixtures/columns-inherit-offset.css
@@ -3,5 +3,5 @@
 @tidy site-max 90rem;
 
 div {
-	tidy-columns: inherit / span 3;
+	tidy-column: inherit / span 3;
 }

--- a/test/fixtures/columns-negative-offset.css
+++ b/test/fixtures/columns-negative-offset.css
@@ -3,5 +3,5 @@
 @tidy site-max 90rem;
 
 div {
-	tidy-columns: -1 / span 3;
+	tidy-column: -1 / span 3;
 }

--- a/test/fixtures/columns-zero-offset.css
+++ b/test/fixtures/columns-zero-offset.css
@@ -3,5 +3,5 @@
 @tidy site-max 90rem;
 
 div {
-	tidy-columns: 0 / span 3;
+	tidy-column: 0 / span 3;
 }

--- a/test/fixtures/columns.css
+++ b/test/fixtures/columns.css
@@ -3,5 +3,5 @@
 @tidy site-max 90rem;
 
 div {
-	tidy-columns: 2 / span 3;
+	tidy-column: 2 / span 3;
 }


### PR DESCRIPTION
This fixes a bug in the `tidy-column` shorthand property.