### PR TITLE
Column shorthand bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,11 @@
 # Change Log
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## next
+* BUGFIX: Corrects `tidy-column` shorthand replacement for third `offset-right` property.
+
 ## 0.2.2
-* Corrects `tidy-column` shorthand matching and replacement.
+* BUGFIX: Corrects `tidy-column` shorthand matching and replacement.
 
 ## 0.2.1
 * Removes unused dependency (`object-assign`).
@@ -11,7 +14,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 * Adds support for CSS Custom Properties in `@tidy` rule values.
 
 ## 0.1.1
-* Fixes locally-scoped options polluting global options.
+* BUGFIX: Locally-scoped options not longer pollute global options.
 
 ## 0.1
 * Initial release.

--- a/lib/tidy-shorthand-property.js
+++ b/lib/tidy-shorthand-property.js
@@ -75,7 +75,7 @@ module.exports = function tidyShorthandProperty(declaration) {
 
     if (undefined !== values.offsetRight) {
       shortHandReplace.push(postcss.decl({
-        prop: 'tidy-offset-left',
+        prop: 'tidy-offset-right',
         value: values.offsetRight,
         source: declaration.source,
       }));

--- a/test/fixtures/columns.css
+++ b/test/fixtures/columns.css
@@ -1,7 +1,8 @@
 @tidy columns 12;
 @tidy gap 1.25rem;
 @tidy site-max 90rem;
+@tidy edge 0.625rem;
 
 div {
-	tidy-column: 2 / span 3;
+	tidy-column: 2 / span 3 / 1;
 }

--- a/test/fixtures/columns.expected.css
+++ b/test/fixtures/columns.expected.css
@@ -1,10 +1,12 @@
 div {
-	width: calc(((100vw / 12 - 1.1458rem) * 3) + 1.25rem * 2);
-	max-width: calc(((90rem / 12 - 1.1458rem) * 3) + 1.25rem * 2);
-	margin-left: calc(((100vw / 12 - 1.1458rem) * 2) + 1.25rem * 2);
+	width: calc((((100vw - 0.625rem * 2) / 12 - 1.1458rem) * 3) + 1.25rem * 2);
+	max-width: calc((((90rem - 0.625rem * 2) / 12 - 1.1458rem) * 3) + 1.25rem * 2);
+	margin-left: calc((((100vw - 0.625rem * 2) / 12 - 1.1458rem) * 2) + 1.25rem * 2);
+	margin-right: calc(((100vw - 0.625rem * 2) / 12 - 1.1458rem) + 1.25rem);
 }
 @media (min-width: 90rem) {
 	div {
-		margin-left: calc(((90rem / 12 - 1.1458rem) * 2) + 1.25rem * 2);
+		margin-left: calc((((90rem - 0.625rem * 2) / 12 - 1.1458rem) * 2) + 1.25rem * 2);
+		margin-right: calc(((90rem - 0.625rem * 2) / 12 - 1.1458rem) + 1.25rem);
 	}
 }


### PR DESCRIPTION
The third argument for `tidy-column` was being replaced incorrectly.