### PR TITLE
Fixes a bug in cleanClone

### DIFF
--- a/lib/cleanClone.js
+++ b/lib/cleanClone.js
@@ -7,8 +7,9 @@
  * @returns {Object}
  */
 module.exports = function cleanClone(node, overrides = {}) {
+  const cleaner = (node.nodes) ? { nodes: [] } : {};
   // Clone the node with overrides.
-  const clonedNode = node.clone(Object.assign(overrides, { nodes: [] }));
+  const clonedNode = node.clone(Object.assign(overrides, cleaner));
   // Clear raw formatting, which will be inherited upon insertion.
   clonedNode.cleanRaws();
 


### PR DESCRIPTION
`node.nodes` was being set, even if it didn't initially exist, which is bad.

postcss/autoprefixer#1115