### PR TITLE
Bugs: `tidy-var()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 **Added**
 
 - Adds support for configuring different grid specs across multiple breakpoints (#20)
-- Adds a `tidy-var()` function for retrieving option values in property values (#27)
+- Adds a `tidy-var()` function for retrieving option values in property values (#27, #32)
 
 **Changed**
 

--- a/test/tidy-var.test.js
+++ b/test/tidy-var.test.js
@@ -52,6 +52,15 @@ describe('The `tidy-var()` function is replaced with the expected option value',
   );
 
   test(
+    'Replaces `tidy-var` when used as a `tidy-*` property value',
+    () => run(
+      'div { tidy-span: tidy-var(12); }',
+      'div { width: calc((((100vw - 0.625rem * 2) / 12 - 1.1458rem) * 12) + 1.25rem * 11); }',
+      typicalWithBreakpoints,
+    ),
+  );
+
+  test(
     'Replaces the correct value from within a matched breakpoint',
     () => run(
       // eslint-disable-next-line max-len
@@ -78,6 +87,14 @@ describe('Matches tidy-var() functions', () => {
     [
       'tidy-var(siteMax)',
       ['tidy-var(siteMax)', 'siteMax'],
+    ],
+    [
+      'tidy-var(columns)',
+      ['tidy-var(columns)', 'columns'],
+    ],
+    [
+      'tidy-span(tidy-var(columns))',
+      ['tidy-var(columns)', 'columns'],
     ],
   ])(
     'Matches %s',

--- a/test/tidy-var.test.js
+++ b/test/tidy-var.test.js
@@ -61,6 +61,15 @@ describe('The `tidy-var()` function is replaced with the expected option value',
   );
 
   test(
+    'Replaces `tidy-var` when used as a `tidy-*` function value',
+    () => run(
+      'div { width: tidy-span(tidy-var(columns)); }',
+      'div { width: calc((((100vw - 0.625rem * 2) / 12 - 1.1458rem) * 12) + 1.25rem * 11); }',
+      typicalWithBreakpoints,
+    ),
+  );
+
+  test(
     'Replaces the correct value from within a matched breakpoint',
     () => run(
       // eslint-disable-next-line max-len

--- a/test/tidy-var.test.js
+++ b/test/tidy-var.test.js
@@ -54,7 +54,7 @@ describe('The `tidy-var()` function is replaced with the expected option value',
   test(
     'Replaces `tidy-var` when used as a `tidy-*` property value',
     () => run(
-      'div { tidy-span: tidy-var(12); }',
+      'div { tidy-span: tidy-var(columns); }',
       'div { width: calc((((100vw - 0.625rem * 2) / 12 - 1.1458rem) * 12) + 1.25rem * 11); }',
       typicalWithBreakpoints,
     ),

--- a/tidy-var.js
+++ b/tidy-var.js
@@ -6,7 +6,7 @@ const cleanClone = require('./lib/cleanClone');
  *
  * @type {RegExp}
  */
-const VAR_FUNCTION_REGEX = /tidy-var\(["']?(edge|gap|siteMax)["']?\)/i;
+const VAR_FUNCTION_REGEX = /tidy-var\(["']?(columns|edge|gap|siteMax)["']?\)/i;
 
 /**
  * Replace `tidy-var()` functions within property values.

--- a/tidy-var.js
+++ b/tidy-var.js
@@ -48,14 +48,18 @@ function tidyVar(declaration, tidy) {
       return acc;
     }, declaration.value);
 
-    // Replace declaration(s) with cloned and updated declarations.
-    declaration.replaceWith(cleanClone(
+    // Clone after so the new declaration can be walked again.
+    // This avoids a situation where another Tidy property or function is within this declaration.
+    declaration.cloneAfter(cleanClone(
       declaration,
       {
         prop: declaration.prop,
         value: replaceWithValue,
       },
     ));
+
+    // Remove the original declaration.
+    declaration.remove();
   }
 }
 


### PR DESCRIPTION
`tidy-var()` should support the following:
- Using `columns` as an argument
- Use as a `tidy-span()` or `tidy-offset()` value

Filing tests added via 513132d