### PR TITLE
Bug: Shorthand properties

### DIFF
--- a/test/tidy-shorthand-property.test.js
+++ b/test/tidy-shorthand-property.test.js
@@ -98,6 +98,10 @@ describe('Matches valid tidy-column shorthand values', () => {
       ['1 / span 6', '1', 'span 6', undefined],
     ],
     [
+      '3',
+      ['3', '3', undefined, undefined],
+    ],
+    [
       '0 / span 2 / 1',
       ['0 / span 2 / 1', '0', 'span 2', '1'],
     ],

--- a/test/tidy-shorthand-property.test.js
+++ b/test/tidy-shorthand-property.test.js
@@ -91,35 +91,35 @@ describe('Matches valid tidy-column shorthand values', () => {
   test.each([
     [
       '2 / span 3 / 1',
-      ['2 / span 3 / 1', '2', '/ span 3', '/ 1'],
+      ['2 / span 3 / 1', '2', 'span 3', '1'],
     ],
     [
       '1 / span 6',
-      ['1 / span 6', '1', '/ span 6', undefined],
+      ['1 / span 6', '1', 'span 6', undefined],
     ],
     [
       '0 / span 2 / 1',
-      ['0 / span 2 / 1', '0', '/ span 2', '/ 1'],
+      ['0 / span 2 / 1', '0', 'span 2', '1'],
     ],
     [
       'none / span 5',
-      ['none / span 5', 'none', '/ span 5', undefined],
+      ['none / span 5', 'none', 'span 5', undefined],
     ],
     [
       '2 / span 1 / none',
-      ['2 / span 1 / none', '2', '/ span 1', '/ none'],
+      ['2 / span 1 / none', '2', 'span 1', 'none'],
     ],
     [
       'none / span 5 / none',
-      ['none / span 5 / none', 'none', '/ span 5', '/ none'],
+      ['none / span 5 / none', 'none', 'span 5', 'none'],
     ],
     [
       '0 / span 4 / none',
-      ['0 / span 4 / none', '0', '/ span 4', '/ none'],
+      ['0 / span 4 / none', '0', 'span 4', 'none'],
     ],
     [
       '-2 / span 3.75 / 1',
-      ['-2 / span 3.75 / 1', '-2', '/ span 3.75', '/ 1'],
+      ['-2 / span 3.75 / 1', '-2', 'span 3.75', '1'],
     ],
   ])(
     'Matches tidy-column: %s',
@@ -137,7 +137,7 @@ describe('Matches valid tidy-offset shorthand values', () => {
   test.each([
     [
       '2 / 1',
-      ['2 / 1', '2', '/ 1'],
+      ['2 / 1', '2', '1'],
     ],
     [
       '1',
@@ -145,15 +145,15 @@ describe('Matches valid tidy-offset shorthand values', () => {
     ],
     [
       'none / 3',
-      ['none / 3', 'none', '/ 3'],
+      ['none / 3', 'none', '3'],
     ],
     [
       '2 / none',
-      ['2 / none', '2', '/ none'],
+      ['2 / none', '2', 'none'],
     ],
     [
       '-2 / 1.5',
-      ['-2 / 1.5', '-2', '/ 1.5'],
+      ['-2 / 1.5', '-2', '1.5'],
     ],
   ])(
     'Matches tidy-offset: %s',

--- a/test/tidy-shorthand-property.test.js
+++ b/test/tidy-shorthand-property.test.js
@@ -74,6 +74,14 @@ describe('The `tidy-offset` shorthand property is replaced with the long-form eq
       'div { tidy-offset-left: 1; tidy-offset-right: 1; }',
     ),
   );
+
+  test(
+    'A single value applies to the span and both offsets',
+    () => runShorthandTest(
+      'div { tidy-column: 3; }',
+      'div { tidy-span: 3; tidy-offset-left: 3; tidy-offset-right: 3; }',
+    ),
+  );
 });
 
 /**
@@ -96,6 +104,22 @@ describe('Matches valid tidy-column shorthand values', () => {
     [
       'none / span 5',
       ['none / span 5', 'none', '/ span 5', undefined],
+    ],
+    [
+      '2 / span 1 / none',
+      ['2 / span 1 / none', '2', '/ span 1', '/ none'],
+    ],
+    [
+      'none / span 5 / none',
+      ['none / span 5 / none', 'none', '/ span 5', '/ none'],
+    ],
+    [
+      '0 / span 4 / none',
+      ['0 / span 4 / none', '0', '/ span 4', '/ none'],
+    ],
+    [
+      '-2 / span 3.75 / 1',
+      ['-2 / span 3.75 / 1', '-2', '/ span 3.75', '/ 1'],
     ],
   ])(
     'Matches tidy-column: %s',
@@ -122,6 +146,14 @@ describe('Matches valid tidy-offset shorthand values', () => {
     [
       'none / 3',
       ['none / 3', 'none', '/ 3'],
+    ],
+    [
+      '2 / none',
+      ['2 / none', '2', '/ none'],
+    ],
+    [
+      '-2 / 1.5',
+      ['-2 / 1.5', '-2', '/ 1.5'],
     ],
   ])(
     'Matches tidy-offset: %s',

--- a/tidy-shorthand-property.js
+++ b/tidy-shorthand-property.js
@@ -6,14 +6,14 @@ const cleanShorthandValues = require('./lib/cleanShorthandValues');
  *
  * @type {RegExp}
  */
-const COLUMNS_REGEX = /^([\d.-]+|none)\s?(\/\s?span\s[\d.-]+)\s?(\/\s?[\d.-]+)?$/;
+const COLUMNS_REGEX = /^([\d.-]+|none)[\s/]*(span\s[\d.-]+)[\s/]*([\d.-]+|none)?$/;
 
 /**
  * Matches valid tidy-offset shorthand values.
  *
  * @type {RegExp}
  */
-const OFFSET_REGEX = /^(\d+|none)\s?(\/\s?\d+)?$/;
+const OFFSET_REGEX = /^([\d.-]+|none)[\s/]*([\d.-]+|none)?$/;
 
 /**
  * Replace `tidy-*` shorthand with long-form equivalents.

--- a/tidy-shorthand-property.js
+++ b/tidy-shorthand-property.js
@@ -6,7 +6,7 @@ const cleanShorthandValues = require('./lib/cleanShorthandValues');
  *
  * @type {RegExp}
  */
-const COLUMNS_REGEX = /^([\d.-]+|none)[\s/]*(span\s[\d.-]+)[\s/]*([\d.-]+|none)?$/;
+const COLUMNS_REGEX = /^([\d.-]+|none)[\s/]*(span\s[\d.-]+)?[\s/]*([\d.-]+|none)?$/;
 
 /**
  * Matches valid tidy-offset shorthand values.
@@ -43,7 +43,7 @@ function tidyShorthandProperty(declaration) {
     // Remove slashes, spaces, and invalid/unneeded values.
     const values = cleanShorthandValues({
       offsetLeft,
-      span,
+      span: span || offsetLeft,
       offsetRight: offsetRight || offsetLeft,
     });
 


### PR DESCRIPTION
- [x] Negative and decimals values are supported in `tidy-offset` values
- [x] `none` as the second `tidy-offset` value is picked up by `OFFSET_REGEX`
- [x] Missing `tidy-column` values are backfilled by the first value
