### PR TITLE
Bug: Should ignore unitless non-zero values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Updates dependencies to fix known vulnerabilities (#26)
 - `tidy-*` functions nested within a `calc()` function are properly detected and escaped (#34)
 - Shorthand properties now accept documented values (#36)
+- Corrects an issue with unitless non-zero config values not being ignored (#39)
 
 **Removed**
 

--- a/src/normalizeOptions.js
+++ b/src/normalizeOptions.js
@@ -7,7 +7,7 @@ const valuesHaveSameUnits = require('../lib/valuesHaveSameUnits');
  *
  * @type {RegExp}
  */
-const LENGTH_REGEX = /^[0-9.]+(px|r?em)?$/;
+const LENGTH_REGEX = /^[0]$|[0-9.]+(px|r?em)+$/;
 
 /**
  * Nomalize, collect and merge breakpoint configs.

--- a/src/test/normalizeOptions.test.js
+++ b/src/test/normalizeOptions.test.js
@@ -218,6 +218,7 @@ describe('Matches CSS length values of the supported unit values (px, em, rem)',
     '8vh',
     '7ch',
     '60 rem',
+    '100',
   ])(
     'Ignores unsupported length values: %s',
     (input) => {


### PR DESCRIPTION
- [x] Non-zero config values with no units or unsupported units are ignored