### PR TITLE
Breakpoints rethink

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,33 +16,33 @@ npm install postcss-tidy-columns
 
 ```js
 require('postcss-tidy-columns')({
-	columns: 12,
-	gap: '1.25rem',
-	edge: '2rem',
-	siteMax: '90rem',
+  columns: 12,
+  gap: '1.25rem',
+  edge: '2rem',
+  siteMax: '90rem',
 });
 ```
 
 ```css
 /* Input example, using the above plugins options */
 div {
-	tidy-span: 3;
-	tidy-offset-left: 2;
+  tidy-span: 3;
+  tidy-offset-left: 2;
 }
 ```
 
 ```css
 /* Output example */
 div {
-	width: calc((((100vw - 2rem * 2) / 12 - 1.1458rem) * 3) + 1.25rem * 2);
-	max-width: calc((((90rem - 2rem * 2) / 12 - 1.1458rem) * 3) + 1.25rem * 2);
-	margin-left: calc((((100vw - 2rem * 2) / 12 - 1.1458rem) * 2) + 1.25rem * 2);
+  width: calc((((100vw - 2rem * 2) / 12 - 1.1458rem) * 3) + 1.25rem * 2);
+  max-width: calc((((90rem - 2rem * 2) / 12 - 1.1458rem) * 3) + 1.25rem * 2);
+  margin-left: calc((((100vw - 2rem * 2) / 12 - 1.1458rem) * 2) + 1.25rem * 2);
 }
 
 @media (min-width: 90rem) {
-	div {
-		margin-left: calc((((90rem - 2rem * 2) / 12 - 1.1458rem) * 2) + 1.25rem * 2);
-	}
+  div {
+    margin-left: calc((((90rem - 2rem * 2) / 12 - 1.1458rem) * 2) + 1.25rem * 2);
+  }
 }
 ```
 
@@ -142,13 +142,13 @@ When using these functions, **the `siteMax`-based static value will not be outpu
 > /* property: calc(tidy-span(number) expression) */
 >
 > div {
-> 	width: calc(tidy-span(3) + 4rem);
+>   width: calc(tidy-span(3) + 4rem);
 > }
 >
 > @media (min-width: 75rem) {
-> 	div {
-> 		width: calc(tidy-span-full(3) + 4rem);
-> 	}
+>   div {
+>     width: calc(tidy-span-full(3) + 4rem);
+>   }
 > }
 > ```
 
@@ -163,13 +163,13 @@ When using these functions, **the `siteMax`-based static value will not be outpu
 > /* property: calc(tidy-offset(number) expression) */
 >
 > div {
-> 	left: calc(tidy-offset(1) + 2rem);
+>   left: calc(tidy-offset(1) + 2rem);
 > }
 >
 > @media (min-width: 75rem) {
-> 	div {
-> 		left: calc(tidy-offset-full(1) + 2rem);
-> 	}
+>   div {
+>     left: calc(tidy-offset-full(1) + 2rem);
+>   }
 > }
 > ```
 
@@ -196,7 +196,7 @@ When using these functions, **the `siteMax`-based static value will not be outpu
 |[`gap`](#gap)|`{String}`|`undefined`|The width of grid column gaps.|
 |[`siteMax`](#siteMax)|`{String}`|`undefined`|The max-width of the site.|
 |[`edge`](#edge)|`{String}`|`undefined`|The value of the site's edge padding.|
-|[`breakpoints`](#breakpoints)|`{Array}`|`[]`|An array of breakpoint-specific configuration objects.|
+|[`breakpoints`](#breakpoints)|`{Object}`|`{}`|Breakpoint-specific configuration options.|
 
 _As an alternative to the [PostCSS] JavaScript API, options may also be passed via stylesheet `@tidy` at-rules._
 
@@ -251,29 +251,27 @@ Supports any positive integer of unit [`px`|`em`|`rem`].
 
 ### `breakpoints`
 
-Use the `breakpoints` array to configure a grid spec that changes across breakpoints.
+Use the `breakpoints` object to define a grid configuration that will change based on screen size.
 
 1. Define the small-screen grid in the root object.
-2. Define `min-width` breakpoints at which the grid spec changes, and any configuration options that will change.
-3. The configuration settings cascade up from the root to the largest `breakpoint`.
+2. Define one or more `min-width` breakpoints at which the grid spec will change, and any configuration options that will change.
+4. The configuration settings cascade up from the root to the largest `breakpoint`.
 
 ```js
 require('postcss-tidy-columns')({
-	columns: 9,
-	edge: '1rem',
-	gap: '0.625rem',
-	breakpoints: [
-		{
-			breakpoint: '48rem',
-			columns: 12,
-			gap: '1rem'
-		},
-		{
-			breakpoint: '64rem',
-			edge: '1.25rem',
-			siteMax: '90rem'
-		}
-	]
+  columns: 9,
+  edge: '1rem',
+  gap: '0.625rem',
+  breakpoints: {
+    '48rem': {
+      columns: 12,
+      gap: '1rem'
+    },
+    '64rem': {
+      edge: '1.25rem',
+      siteMax: '90rem'
+    }
+  },
 });
 ```
 

--- a/lib/sort.js
+++ b/lib/sort.js
@@ -15,20 +15,7 @@ function strings() {
   return collator.compare;
 }
 
-/**
- * Sort an array of objects by an object property.
- *
- * @param {Array}  objs     An array of objects.
- * @param {String} property The property name to sort the objects by.
- *
- * @return {Array}
- */
-function objectsByProperty(property) {
-  return (a, b) => a[property].localeCompare(b[property], undefined, sortOptions);
-}
-
 module.exports = {
   strings,
-  objectsByProperty,
   sortOptions,
 };

--- a/lib/test/sort.test.js
+++ b/lib/test/sort.test.js
@@ -1,4 +1,4 @@
-const { strings, objectsByProperty } = require('../sort');
+const { strings } = require('../sort');
 
 /**
  * Sort array of strings.
@@ -29,24 +29,4 @@ describe('Sort array of strings', () => {
       expect(input.sort(strings())).toEqual(input);
     },
   );
-});
-
-/**
- * Sort an array of objects by an object property.
- */
-describe('Sort an array of objects by an object property', () => {
-  test('Sorts an array of objects by property', () => {
-    /* eslint-disable function-paren-newline */
-    expect(
-      [
-        { breakpoint: '1000px', boo: 100 },
-        { breakpoint: '600px', foo: 0 },
-        { breakpoint: '400px', baz: 'zoo' },
-      ].sort(objectsByProperty('breakpoint')))
-      .toEqual([
-        { breakpoint: '400px', baz: 'zoo' },
-        { breakpoint: '600px', foo: 0 },
-        { breakpoint: '1000px', boo: 100 },
-      ]);
-  });
 });

--- a/src/breakpointMatch.js
+++ b/src/breakpointMatch.js
@@ -1,6 +1,5 @@
 const { parseAtruleParams } = require('../lib/parseAtruleParams');
 const compareStrings = require('../lib/compareStrings');
-const getObjectByProperty = require('../lib/getObjectByProperty');
 
 /**
  * Check if an atrule.param is within a range of breakpoints.
@@ -14,7 +13,8 @@ const getObjectByProperty = require('../lib/getObjectByProperty');
  * @return {Object} The matching options breakpoint object, or undefined.
  */
 function breakpointMatch(params, options) {
-  const { collectedBreakpointValues } = options;
+  const { breakpoints } = options;
+  const collectedBreakpointValues = Object.keys(breakpoints);
 
   if (undefined === collectedBreakpointValues) {
     return undefined;
@@ -29,7 +29,7 @@ function breakpointMatch(params, options) {
 
     // If the breakpoints array contains the value, just return it.
     if (breakpointValues.includes(value)) {
-      return getObjectByProperty(options.breakpoints, value, 'breakpoint');
+      return options.breakpoints[value];
     }
 
     // Reverse the breakpoints array for min value matching.
@@ -44,7 +44,7 @@ function breakpointMatch(params, options) {
     }, '');
 
     // Return the options breakpoint object, or undefined if not found.
-    return getObjectByProperty(options.breakpoints, matchingBp, 'breakpoint');
+    return options.breakpoints[matchingBp];
   });
 
   // Creating a Set removes duplicates.

--- a/src/test/breakpointMatch.test.js
+++ b/src/test/breakpointMatch.test.js
@@ -8,39 +8,31 @@ const breakpointMatch = require('../breakpointMatch');
 describe('Get options based on a matching breakpoint value.', () => {
   // Parsed options.
   const options = {
-    breakpoints: [
-      {
-        breakpoint: '768px',
+    breakpoints: {
+      '768px': {
         gap: '0.625rem',
       },
-      {
-        breakpoint: '1024px',
+      '1024px': {
         gap: '1rem',
       },
-      {
-        breakpoint: '1440px',
+      '1440px': {
         gap: '1.25rem',
       },
-    ],
-    collectedBreakpointValues: [
-      '768px',
-      '1024px',
-      '1440px',
-    ],
+    },
   };
 
   test.each([
     [
       '(min-width: 900px)',
-      { breakpoint: '768px', gap: '0.625rem' },
+      { gap: '0.625rem' },
     ],
     [
       '(max-width: 900px)',
-      { breakpoint: '768px', gap: '0.625rem' },
+      { gap: '0.625rem' },
     ],
     [
       '(min-width: 768px) and (max-width: 1023px)',
-      { breakpoint: '768px', gap: '0.625rem' },
+      { gap: '0.625rem' },
     ],
   ])(
     'Matches %s',
@@ -74,18 +66,16 @@ const options = {
   columns: 9,
   edge: '1rem',
   gap: '0.625rem',
-  breakpoints: [
-    {
-      breakpoint: '48rem',
+  breakpoints: {
+    '48rem': {
       columns: 12,
       gap: '1rem',
     },
-    {
-      breakpoint: '64rem',
+    '64rem': {
       edge: '1.25rem',
       siteMax: '90rem',
     },
-  ],
+  },
 };
 
 describe('The functions and properties values are replaced according a breakpoint match', () => {

--- a/src/test/getLocalOptions.test.js
+++ b/src/test/getLocalOptions.test.js
@@ -58,28 +58,16 @@ describe('Declarations use the correct option values', () => {
         columns: 12,
         edge: '0.625rem',
         gap: '0.625rem',
-        breakpoints: [
-          {
-            breakpoint: '768px',
+        breakpoints: {
+          '768px': {
             gap: '0.625rem',
           },
-          {
-            breakpoint: '1024px',
+          '1024px': {
             siteMax: '90rem',
           },
-        ],
-        breakpoint: '768px',
-        collectedBreakpointValues: [
-          '768px',
-          '1024px',
-        ],
+        },
       },
-      Object.assign(typicalWithBreakpoints, {
-        collectedBreakpointValues: [
-          '768px',
-          '1024px',
-        ],
-      }),
+      typicalWithBreakpoints,
     ),
   );
 
@@ -91,20 +79,14 @@ describe('Declarations use the correct option values', () => {
         columns: 12,
         edge: '0.625rem',
         gap: '1.25rem',
-        breakpoints: [
-          {
-            breakpoint: '768px',
+        breakpoints: {
+          '768px': {
             gap: '0.625rem',
           },
-          {
-            breakpoint: '1024px',
+          '1024px': {
             siteMax: '90rem',
           },
-        ],
-        collectedBreakpointValues: [
-          '768px',
-          '1024px',
-        ],
+        },
       },
       typicalWithBreakpoints,
     ),

--- a/src/test/normalizeOptions.test.js
+++ b/src/test/normalizeOptions.test.js
@@ -28,29 +28,24 @@ describe('Normalize option value types', () => {
       edge: '1rem',
       gap: '0.625rem',
       siteMax: '90rem',
-      breakpoints: [
-        {
-          breakpoint: '48rem',
+      breakpoints: {
+        '48rem': {
           gap: '1rem',
           edge: '1.25rem',
         },
-      ],
+      },
     }))
       .toEqual({
         columns: 12,
         edge: '1rem',
         gap: '0.625rem',
         siteMax: '90rem',
-        breakpoints: [
-          {
-            breakpoint: '48rem',
+        breakpoints: {
+          '48rem': {
             gap: '1rem',
             edge: '1.25rem',
           },
-        ],
-        collectedBreakpointValues: [
-          '48rem',
-        ],
+        },
       });
   });
 
@@ -60,121 +55,92 @@ describe('Normalize option value types', () => {
       edge: '1rem',
       gap: '0.625rem',
       siteMax: '90rem',
-      breakpoints: [
-        {
-          breakpoint: '48rem',
+      breakpoints: {
+        '48rem': {
           gap: '1rem',
         },
-        {
-          breakpoint: '64rem',
+        '64rem': {
           edge: '1.25rem',
         },
-      ],
+      },
     }))
       .toEqual({
         columns: 12,
         edge: '1rem',
         gap: '0.625rem',
         siteMax: '90rem',
-        breakpoints: [
-          {
-            breakpoint: '48rem',
+        breakpoints: {
+          '48rem': {
             gap: '1rem',
           },
-          {
-            breakpoint: '64rem',
+          '64rem': {
             gap: '1rem',
             edge: '1.25rem',
           },
-        ],
-        collectedBreakpointValues: [
-          '48rem',
-          '64rem',
-        ],
+        },
       });
   });
 });
 
 describe('Nomalize, collect and merge breakpoint configs', () => {
   test('Converts breakpoint value with no units to `px`', () => {
-    expect(handleBreakpointConfigs([
-      {
-        breakpoint: 768,
+    expect(handleBreakpointConfigs({
+      768: {
         gap: '1rem',
         edge: '1.25rem',
       },
-    ], {}))
+    }, {}))
       .toEqual({
-        breakpoints: [
-          {
-            breakpoint: '768px',
+        breakpoints: {
+          '768px': {
             gap: '1rem',
             edge: '1.25rem',
           },
-        ],
-        collectedBreakpointValues: [
-          '768px',
-        ],
+        },
       });
   });
 
   test('Collects, merges, and sorts breakpoint values declared out-of-order', () => {
-    expect(handleBreakpointConfigs([
-      {
-        breakpoint: 1024,
+    expect(handleBreakpointConfigs({
+      1024: {
         gap: '1.25rem',
       },
-      {
-        breakpoint: '768px',
+      '768px': {
         edge: '1.25rem',
       },
-    ], {}))
+    }, {}))
       .toEqual({
-        breakpoints: [
-          {
-            breakpoint: '768px',
+        breakpoints: {
+          '768px': {
             edge: '1.25rem',
           },
-          {
-            breakpoint: '1024px',
+          '1024px': {
             gap: '1.25rem',
             edge: '1.25rem',
           },
-        ],
-        collectedBreakpointValues: [
-          '768px',
-          '1024px',
-        ],
+        },
       });
   });
 
   test('Collects and merges breakpoint values with `0` overrrides', () => {
-    expect(handleBreakpointConfigs([
-      {
-        breakpoint: '48rem',
+    expect(handleBreakpointConfigs({
+      '48rem': {
         gap: '1rem',
       },
-      {
-        breakpoint: '64rem',
+      '64rem': {
         edge: 0,
       },
-    ], {}))
+    }, {}))
       .toEqual({
-        breakpoints: [
-          {
-            breakpoint: '48rem',
+        breakpoints: {
+          '48rem': {
             gap: '1rem',
           },
-          {
-            breakpoint: '64rem',
+          '64rem': {
             gap: '1rem',
             edge: 0,
           },
-        ],
-        collectedBreakpointValues: [
-          '48rem',
-          '64rem',
-        ],
+        },
       });
   });
 });

--- a/test/sharedConfigs.js
+++ b/test/sharedConfigs.js
@@ -66,15 +66,13 @@ module.exports = {
     columns: 12,
     gap: '1.25rem',
     edge: '0.625rem',
-    breakpoints: [
-      {
-        breakpoint: '768px',
+    breakpoints: {
+      '768px': {
         gap: '0.625rem',
       },
-      {
-        breakpoint: '1024px',
+      '1024px': {
         siteMax: '90rem',
       },
-    ],
+    },
   },
 };


### PR DESCRIPTION
This revamps the format for configuring `breakpoints`.

```javascript
{
  gap: '1rem',
  breakpoints: {
    '48rem': {
      gap: '1.5rem',
    },
  },
}
```