### PR TITLE
Adds `debug` mode option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 - Adds support for configuring different grid specs across multiple breakpoints (#20)
 - Adds a `tidy-var()` function for retrieving option values in property values (#27, #32)
+- Adds `debug` option for maintaining the input declaration as a comment (#45)
 
 **Changed**
 

--- a/README.md
+++ b/README.md
@@ -196,8 +196,8 @@ When using these functions, **the `siteMax`-based static value will not be outpu
 |[`gap`](#gap)|`{String}`|`undefined`|The width of grid column gaps.|
 |[`siteMax`](#siteMax)|`{String}`|`undefined`|The max-width of the site.|
 |[`edge`](#edge)|`{String}`|`undefined`|The value of the site's edge padding.|
-|[`breakpoints`](#breakpoints)|`{Object}`|`{}`|Breakpoint-specific configuration options.|
 |[`debug`](#debug)|`{Boolean}`|`false`|Add debug comments.|
+|[`breakpoints`](#breakpoints)|`{Object}`|`{}`|Breakpoint-specific configuration options.|
 
 _As an alternative to the [PostCSS] JavaScript API, some options may also be passed via stylesheet `@tidy` at-rules._
 
@@ -250,6 +250,24 @@ Supports any positive integer of unit [`px`|`em`|`rem`].
 > @tidy edge <length>;
 > ```
 
+### `debug`
+
+Set `debug` to `true` to maintain the pre-processed CSS declaration as a comment.
+
+```css
+div {
+  /* tidy-span: 3 */
+  width: calc((((100vw - 2rem * 2) / 12 - 1.1458rem) * 3) + 1.25rem * 2);
+  max-width: calc((((90rem - 2rem * 2) / 12 - 1.1458rem) * 3) + 1.25rem * 2);
+}
+```
+
+> #### CSS Syntax
+>
+> ```
+> @tidy debug <boolean>;
+> ```
+
 ### `breakpoints`
 
 Use the `breakpoints` object to define a grid configuration that will change based on screen size.
@@ -277,18 +295,6 @@ require('postcss-tidy-columns')({
 ```
 
 See the [Scoped Settings](../../wiki/Scoped-Settings) Wiki page for more.
-
-### `debug`
-
-Set `debug` to `true` to maintain the pre-processed CSS declarations as comments.
-
-```css
-div {
-  /* tidy-span: 3 */
-  width: calc((((100vw - 2rem * 2) / 12 - 1.1458rem) * 3) + 1.25rem * 2);
-  max-width: calc((((90rem - 2rem * 2) / 12 - 1.1458rem) * 3) + 1.25rem * 2);
-}
-```
 
 ## Options Cascade
 

--- a/README.md
+++ b/README.md
@@ -197,8 +197,9 @@ When using these functions, **the `siteMax`-based static value will not be outpu
 |[`siteMax`](#siteMax)|`{String}`|`undefined`|The max-width of the site.|
 |[`edge`](#edge)|`{String}`|`undefined`|The value of the site's edge padding.|
 |[`breakpoints`](#breakpoints)|`{Object}`|`{}`|Breakpoint-specific configuration options.|
+|[`debug`](#debug)|`{Boolean}`|`false`|Add debug comments.|
 
-_As an alternative to the [PostCSS] JavaScript API, options may also be passed via stylesheet `@tidy` at-rules._
+_As an alternative to the [PostCSS] JavaScript API, some options may also be passed via stylesheet `@tidy` at-rules._
 
 ### `columns`
 
@@ -276,6 +277,18 @@ require('postcss-tidy-columns')({
 ```
 
 See the [Scoped Settings](../../wiki/Scoped-Settings) Wiki page for more.
+
+### `debug`
+
+Set `debug` to `true` to maintain the pre-processed CSS declarations as comments.
+
+```css
+div {
+  /* tidy-span: 3 */
+  width: calc((((100vw - 2rem * 2) / 12 - 1.1458rem) * 3) + 1.25rem * 2);
+  max-width: calc((((90rem - 2rem * 2) / 12 - 1.1458rem) * 3) + 1.25rem * 2);
+}
+```
 
 ## Options Cascade
 

--- a/index.js
+++ b/index.js
@@ -23,7 +23,7 @@ module.exports = postcss.plugin(
 
       // Replace shorthand declarations with their long-form equivalents.
       rule.walkDecls(/^tidy-(column|offset)$/, (declaration) => {
-        tidyShorthandProperty(declaration);
+        tidyShorthandProperty(declaration, tidy);
       });
 
       // Set up rule-specific properties.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "postcss-tidy-columns",
-  "version": "0.4.0-beta4",
+  "version": "0.4.0-beta5",
   "description": "PostCSS plugin to manage column and margin alignment.",
   "keywords": [
     "postcss",

--- a/src/getGlobalOptions.js
+++ b/src/getGlobalOptions.js
@@ -17,6 +17,7 @@ function getGlobalOptions(root, options) {
     gap: undefined,
     siteMax: undefined,
     edge: undefined,
+    debug: false,
     breakpoints: [],
   };
 

--- a/src/normalizeOptions.js
+++ b/src/normalizeOptions.js
@@ -80,6 +80,11 @@ function normalizeOptions(options) {
           acc[key] = Number(option);
         }
 
+        // `debug` should be a Boolean value.
+        if ('debug' === key && ['true', 'false'].includes(String(option))) {
+          acc[key] = ('true' === String(option));
+        }
+
         // These should all be valid, positive CSS length values.
         if (['gap', 'edge', 'siteMax'].includes(key) && LENGTH_REGEX.test(option)) {
           // Force `undefined` in place of unitless non-zero value.

--- a/src/test/getGlobalOptions.test.js
+++ b/src/test/getGlobalOptions.test.js
@@ -28,9 +28,25 @@ describe('Collect and merge global plugin options', () => {
         edge: '0.625rem',
         gap: '1.25rem',
         siteMax: '90rem',
+        debug: false,
         breakpoints: [],
       },
       typical,
+    ),
+  );
+
+  test(
+    'Global debug option is collected as expected',
+    () => runGlobalOptionsPlugin(
+      {
+        columns: 12,
+        edge: '0.625rem',
+        gap: '1.25rem',
+        siteMax: '90rem',
+        debug: true,
+        breakpoints: [],
+      },
+      { ...typical, debug: true },
     ),
   );
 
@@ -43,6 +59,7 @@ describe('Collect and merge global plugin options', () => {
         edge: undefined,
         gap: undefined,
         siteMax: undefined,
+        debug: false,
       },
       {},
     ),

--- a/src/test/getLocalOptions.test.js
+++ b/src/test/getLocalOptions.test.js
@@ -39,10 +39,11 @@ describe('Walk any `tidy` at-rules and collect locally-scoped options.', () => {
   test(
     '@tidy value adds a global option',
     () => runLocalOptionsPlugin(
-      'div { @tidy site-max 90rem; }',
+      'div { @tidy site-max 90rem; @tidy debug true; }',
       {
         columns: 12,
         siteMax: '90rem',
+        debug: true,
       },
       columnsOnly,
     ),

--- a/test/tidy-function.test.js
+++ b/test/tidy-function.test.js
@@ -51,6 +51,24 @@ describe('The `tidy-offset` functions are replaced and their values reflect the 
       typical,
     ),
   );
+
+  test(
+    'Maintains `tidy-offset` input as a /* comment */',
+    () => run(
+      'div { margin-left: tidy-offset(1); }',
+      'div { /* margin-left: tidy-offset(1) */ margin-left: calc(((100vw - 0.625rem * 2) / 12 - 1.1458rem) + 1.25rem); }',
+      { ...typical, debug: true },
+    ),
+  );
+
+  test(
+    'Maintains `tidy-offset-full` input as a /* comment */',
+    () => run(
+      'div { margin-left: tidy-offset-full(1); }',
+      'div { /* margin-left: tidy-offset-full(1) */ margin-left: calc(((90rem - 0.625rem * 2) / 12 - 1.1458rem) + 1.25rem); }',
+      { ...typical, debug: true },
+    ),
+  );
 });
 
 describe('The `tidy-span()` functions are replaced and their values reflect the expected options', () => {

--- a/test/tidy-property.test.js
+++ b/test/tidy-property.test.js
@@ -84,6 +84,15 @@ describe('The `tidy-span` property is replaced and its values reflect the expect
       { ...edgeGap, debug: true },
     ),
   );
+
+  test(
+    'Maintains `tidy-span` input as a /* comment */ via `@tidy debug` atRule',
+    () => run(
+      'div { @tidy debug true; tidy-span: 2; }',
+      'div { /* tidy-span: 2 */ width: calc((((100vw - 1rem * 2) / 12 - 9.1667px) * 2) + 10px); }',
+      edgeGap,
+    ),
+  );
 });
 
 /**

--- a/test/tidy-property.test.js
+++ b/test/tidy-property.test.js
@@ -37,6 +37,15 @@ describe('The `tidy-offset-*` properties are replaced and their values reflect t
       edgeGap,
     ),
   );
+
+  test(
+    'Maintains `tidy-offset-right` input as a /* comment */',
+    () => run(
+      'div { tidy-offset-right: 2; }',
+      'div { /* tidy-offset-right: 2 */ margin-right: calc((((100vw - 1rem * 2) / 12 - 9.1667px) * 2) + 10px * 2); }',
+      { ...edgeGap, debug: true },
+    ),
+  );
 });
 
 describe('The `tidy-span` property is replaced and its values reflect the expected options', () => {
@@ -64,6 +73,15 @@ describe('The `tidy-span` property is replaced and its values reflect the expect
       'div { margin-left: calc(tidy-offset(10) + tidy-var(edge)); tidy-span: 2; }',
       'div { margin-left: calc(((((100vw - 32px * 2) / 16 - 0.5859rem) * 10) + 0.625rem * 10) + 32px); width: calc((((100vw - 32px * 2) / 16 - 0.5859rem) * 2) + 0.625rem); max-width: calc((((75rem - 32px * 2) / 16 - 0.5859rem) * 2) + 0.625rem); }',
       allValues,
+    ),
+  );
+
+  test(
+    'Maintains `tidy-span` input as a /* comment */',
+    () => run(
+      'div { tidy-span: 2; }',
+      'div { /* tidy-span: 2 */ width: calc((((100vw - 1rem * 2) / 12 - 9.1667px) * 2) + 10px); }',
+      { ...edgeGap, debug: true },
     ),
   );
 });

--- a/test/tidy-shorthand-property.test.js
+++ b/test/tidy-shorthand-property.test.js
@@ -1,3 +1,4 @@
+/* eslint-disable max-len */
 const postcss = require('postcss');
 const run = require('.');
 const {
@@ -10,12 +11,13 @@ const {
  * Create a test plugin to replace shorthand properties. Running a test plugin
  * limits the scope, which prevents any other features of the plugin from running.
  */
-const runShorthandTest = (input, output) => (
-  run(input, output, {}, postcss.plugin(
+const runShorthandTest = (input, output, options = {}) => (
+  run(input, output, options, postcss.plugin(
     'shorthand-props-test',
     () => function process(root) {
       root.walkDecls((declaration) => {
-        tidyShorthandProperty(declaration);
+        // Pass in a mock Tidy object.
+        tidyShorthandProperty(declaration, { columns: { options } });
       });
     },
   ))
@@ -46,6 +48,15 @@ describe('The `tidy-column` shorthand property is replaced with the long-form eq
     () => runShorthandTest(
       'div { tidy-column: 1 / span 2; }',
       'div { tidy-span: 2; tidy-offset-left: 1; tidy-offset-right: 1; }',
+    ),
+  );
+
+  test(
+    'Maintains `tidy-column` input as a /* comment */',
+    () => runShorthandTest(
+      'div { tidy-column: 1 / span 2 / 3; }',
+      'div { /* tidy-column: 1 / span 2 / 3 */ tidy-span: 2; tidy-offset-left: 1; tidy-offset-right: 3; }',
+      { debug: true },
     ),
   );
 });
@@ -80,6 +91,15 @@ describe('The `tidy-offset` shorthand property is replaced with the long-form eq
     () => runShorthandTest(
       'div { tidy-column: 3; }',
       'div { tidy-span: 3; tidy-offset-left: 3; tidy-offset-right: 3; }',
+    ),
+  );
+
+  test(
+    'Maintains `tidy-offset` input as a /* comment */',
+    () => runShorthandTest(
+      'div { tidy-offset: 1 / 3; }',
+      'div { /* tidy-offset: 1 / 3 */ tidy-offset-left: 1; tidy-offset-right: 3; }',
+      { debug: true },
     ),
   );
 });

--- a/test/tidy-var.test.js
+++ b/test/tidy-var.test.js
@@ -78,6 +78,15 @@ describe('The `tidy-var()` function is replaced with the expected option value',
       typicalWithBreakpoints,
     ),
   );
+
+  test(
+    'Maintains `tidy-var` input as a /* comment */',
+    () => run(
+      'div { margin-left: tidy-var(gap); }',
+      'div { /* margin-left: tidy-var(gap) */ margin-left: 1.25rem; }',
+      { ...typical, debug: true },
+    ),
+  );
 });
 
 /**

--- a/tidy-function.js
+++ b/tidy-function.js
@@ -1,3 +1,4 @@
+const postcss = require('postcss');
 const cleanClone = require('./lib/cleanClone');
 const detectCalcWrapper = require('./lib/detectCalcWrapper');
 
@@ -22,7 +23,8 @@ function tidyFunction(declaration, tidy) {
   const tidyMatches = detectCalcWrapper(declaration.value);
 
   if (0 < tidyMatches.length) {
-    const { columns } = tidy;
+    const { columns, columns: { options } } = tidy;
+
     /**
      * Find all matches in the declaration value.
      *
@@ -62,6 +64,11 @@ function tidyFunction(declaration, tidy) {
         // tidy-[span|offset] ()
         : acc.replace(match, fluid);
     }, declaration.value);
+
+    // Save the original declaration in a comment for debugging.
+    if (options.debug) {
+      declaration.cloneBefore(postcss.comment({ text: declaration }));
+    }
 
     // Replace declaration(s) with cloned and updated declarations.
     declaration.replaceWith(cleanClone(

--- a/tidy-property.js
+++ b/tidy-property.js
@@ -1,3 +1,4 @@
+const postcss = require('postcss');
 const cleanClone = require('./lib/cleanClone');
 
 /**
@@ -21,7 +22,7 @@ const OFFSET_REGEX = /tidy-offset-(left|right)/;
  * @param {Object} tidy        An instance of the Tidy class.
  */
 function tidyProperty(declaration, tidy) {
-  const { fullWidthRule, columns } = tidy;
+  const { fullWidthRule, columns, columns: { options } } = tidy;
 
   // Replace `tidy-span` declaration with a `width` declaration.
   if ('tidy-span' === declaration.prop) {
@@ -32,6 +33,11 @@ function tidyProperty(declaration, tidy) {
     const { fluid, full } = columns.spanCalc(declaration.value);
 
     const columnDecl = [];
+
+    // Save the original declaration in a comment for debugging.
+    if (options.debug) {
+      declaration.cloneBefore(postcss.comment({ text: declaration }));
+    }
 
     columnDecl.push(cleanClone(
       declaration,
@@ -67,6 +73,11 @@ function tidyProperty(declaration, tidy) {
      * full:  calc() function based on `siteMax` base.
      */
     const { fluid, full } = columns.offsetCalc(declaration.value);
+
+    // Save the original declaration in a comment for debugging.
+    if (options.debug) {
+      declaration.cloneBefore(postcss.comment({ text: declaration }));
+    }
 
     // Clone the declaration with `fluid` declaration overrides.
     const fluidDecl = cleanClone(

--- a/tidy-shorthand-property.js
+++ b/tidy-shorthand-property.js
@@ -1,3 +1,4 @@
+const postcss = require('postcss');
 const cleanClone = require('./lib/cleanClone');
 const cleanShorthandValues = require('./lib/cleanShorthandValues');
 
@@ -21,9 +22,11 @@ const OFFSET_REGEX = /^([\d.-]+|none)[\s/]*([\d.-]+|none)?$/;
  * @see https://github.com/goodguyry/postcss-tidy-columns#column-shorthand
  *
  * @param {Object} declaration The CSS declaration.
+ * @param {Object} tidy        An instance of the Tidy class.
  */
-function tidyShorthandProperty(declaration) {
+function tidyShorthandProperty(declaration, tidy) {
   const shortHandReplace = [];
+  const { columns: { options } } = tidy;
 
   /**
    * Replace `tidy-column` shorthand, based on delcaration values.
@@ -46,6 +49,11 @@ function tidyShorthandProperty(declaration) {
       span: span || offsetLeft,
       offsetRight: offsetRight || offsetLeft,
     });
+
+    // Save the original declaration in a comment for debugging.
+    if (options.debug) {
+      declaration.cloneBefore(postcss.comment({ text: declaration }));
+    }
 
     // Conditionally add the `tidy-span` property.
     if (undefined !== values.span) {
@@ -102,6 +110,11 @@ function tidyShorthandProperty(declaration) {
       offsetLeft,
       offsetRight: offsetRight || offsetLeft,
     });
+
+    // Save the original declaration in a comment for debugging.
+    if (options.debug) {
+      declaration.cloneBefore(postcss.comment({ text: declaration }));
+    }
 
     // Conditionally add the `tidy-offset-left` property.
     if (undefined !== values.offsetLeft) {

--- a/tidy-var.js
+++ b/tidy-var.js
@@ -1,4 +1,5 @@
 /* eslint-disable no-param-reassign */
+const postcss = require('postcss');
 const cleanClone = require('./lib/cleanClone');
 
 /**
@@ -21,7 +22,7 @@ function tidyVar(declaration, tidy) {
   const localRegExp = new RegExp(VAR_FUNCTION_REGEX);
 
   if (localRegExp.test(declaration.value)) {
-    const { columns } = tidy;
+    const { columns, columns: { options } } = tidy;
     const fullMatch = declaration.value.match(globalRegExp);
 
     /**
@@ -47,6 +48,11 @@ function tidyVar(declaration, tidy) {
       // There's no corresponding option value.
       return acc;
     }, declaration.value);
+
+    // Save the original declaration in a comment for debugging.
+    if (options.debug) {
+      declaration.cloneBefore(postcss.comment({ text: declaration }));
+    }
 
     // Clone after so the new declaration can be walked again.
     // This avoids a situation where another Tidy property or function is within this declaration.


### PR DESCRIPTION
This adds support for maintaining the preprocessed Tidy Columns declarations as comments. Can be enabled globally or scoped to a specific rule via `@tidy debug true`