### PR TITLE
Adds !tidy support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 **Added**
 
-- Support for configuring different grid specs across multiple breakpoints (#20)
+- Support for configuring different column specs across multiple breakpoints (#20)
 - Use the `tidy-var()` function to retrieve option values in declarations (#27, #32)
 - Use the `debug` option to maintain the input declaration as a comment (#45, #48)
 
@@ -22,7 +22,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 **Removed**
 
-- The `addGap` option for automatically adding the grid gap margin to column elements (#24)
+- The `addGap` option for automatically adding the column gap margin to column elements (#24)
 - Support for Node 6 (#41)
 
 ## 0.3.4

--- a/README.md
+++ b/README.md
@@ -190,6 +190,31 @@ When using these functions, **the `siteMax`-based static value will not be outpu
 > }
 > ```
 
+## `!tidy` Rule
+
+`!tidy` signifies that a declaration should cascade through configured 
+breakpoint changes.
+
+> #### Example
+>
+> ```css
+> /* Assuming there's only one '64rem' breakpoint change configured this... */
+> div {
+>   tidy-span: 3 !tidy;
+> }
+>
+> /* ...is identical to this */
+> div {
+>   tidy-span: 3;
+> }
+>
+> @media (min-width: 64rem) {
+>   div {
+>     tidy-span: 3;
+>   }
+> }
+> ```
+
 ## Options
 
 |Name|Type|Default|Description|

--- a/README.md
+++ b/README.md
@@ -331,7 +331,7 @@ require('postcss-tidy-columns')({
 });
 ```
 
-See the [Scoped Settings](https://github.com/goodguyry/postcss-tidy-columns/wiki/Scoped-Settings) Wiki page for more.
+See the [Gotchas](https://github.com/goodguyry/postcss-tidy-columns/wiki/Gotchas#configuration-breakpoints-caveats) Wiki page for more.
 
 ## Options Cascade
 

--- a/README.md
+++ b/README.md
@@ -229,8 +229,8 @@ breakpoint changes.
 
 |Name|Type|Default|Description|
 |:--:|:--:|:-----:|:----------|
-|[`columns`](#columns)|`{Number}`|`undefined`|The number of grid columns.|
-|[`gap`](#gap)|`{String}`|`undefined`|The width of grid column gaps.|
+|[`columns`](#columns)|`{Number}`|`undefined`|The number of columns.|
+|[`gap`](#gap)|`{String}`|`undefined`|The width of column gaps.|
 |[`siteMax`](#siteMax)|`{String}`|`undefined`|The max-width of the site.|
 |[`edge`](#edge)|`{String}`|`undefined`|The value of the site's edge padding.|
 |[`debug`](#debug)|`{Boolean}`|`false`|Add debug comments.|
@@ -307,10 +307,10 @@ div {
 
 ### `breakpoints`
 
-Use the `breakpoints` object to define a grid configuration that will change based on screen size.
+Use the `breakpoints` object to define a columns configuration that will change based on screen size.
 
-1. Define the small-screen grid in the root object.
-2. Define one or more `min-width` breakpoints at which the grid spec will change, and any configuration options that will change.
+1. Define the small-screen columns configuration in the root object.
+2. Define one or more `min-width` breakpoints at which the columns configuration will change, and any configuration options that will change.
 4. The configuration settings cascade up from the root to the largest `breakpoint`.
 
 ```js

--- a/README.md
+++ b/README.md
@@ -132,7 +132,13 @@ Use `none` to bypass a required value. A single value applies to both `left` and
 
 These functions are provided for incorporating the `tidy-` properties' output without using the properties themselves. These can be used on their own or nested inside a `calc()` function, and allow for more control over the declarations added by the plugin.
 
-When using these functions, **the `siteMax`-based static value will not be output**. Use the `tidy-span-full()` and `tidy-offset-full()` functions to set the static `span` and `offset` widths, respectively.
+**Unlike the above _properties_, these functions only output one value:**
+* `tidy-[offset|span]()` outputs the fluid value
+* `tidy-[offset|span]-full()` outputs the static value, based on the `siteMax` in the configuration.
+
+Be sure to use the function most appropriate for your use-case. Typically, this means redeclaring the the `-full` version of the function in the breakpoint at which the site becomes static width. 
+
+**TIP:** For any function declarations that should stay the same across breakpoint configurations, or simply to redclare the `-full` version of a function, append the declaration with `!tidy` to signal to the plugin to handle duplicating the declaration.
 
 ### Span Function
 
@@ -198,13 +204,16 @@ breakpoint changes.
 
 > #### Example
 >
+> Assuming one '64rem' breakpoint change configured...
+>
 > ```css
-> /* Assuming there's only one '64rem' breakpoint change configured, this... */
+>
+> /* Input: */
 > div {
 >   tidy-span: 3 !tidy;
 > }
 >
-> /* ...is identical to this: */
+> /* Output: */
 > div {
 >   tidy-span: 3;
 > }

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ See [PostCSS] docs for examples for your environment.
 
 * [Tidy Properties](#tidy-properties)
 * [Tidy Functions](#tidy-functions)
+* [!tidy Rule](#tidy-rule)
 * [Options](#options)
 * [Options Cascade](#options-cascade)
 * [Using CSS Custom Properties in setting values](#using-css-custom-properties-in-setting-values)
@@ -198,12 +199,12 @@ breakpoint changes.
 > #### Example
 >
 > ```css
-> /* Assuming there's only one '64rem' breakpoint change configured this... */
+> /* Assuming there's only one '64rem' breakpoint change configured, this... */
 > div {
 >   tidy-span: 3 !tidy;
 > }
 >
-> /* ...is identical to this */
+> /* ...is identical to this: */
 > div {
 >   tidy-span: 3;
 > }

--- a/Tidy.js
+++ b/Tidy.js
@@ -1,4 +1,3 @@
-const postcss = require('postcss');
 const Columns = require('./Columns');
 const getLocalOptions = require('./src/getLocalOptions');
 const cleanClone = require('./lib/cleanClone');
@@ -16,7 +15,6 @@ class Tidy {
 
     // Bind class methods.
     this.initRule = this.initRule.bind(this);
-    this.collectBreakpointAtRules = this.collectBreakpointAtRules.bind(this);
 
     // Merge global and local options.
     const currentOptions = getLocalOptions(this.rule, globalOptions);
@@ -25,9 +23,6 @@ class Tidy {
     if (Object.prototype.hasOwnProperty.call(currentOptions, 'breakpoint')) {
       delete currentOptions.breakpoint;
     }
-
-    // Create and store an atRule for each breakpoint in the config.
-    this.atRules = this.collectBreakpointAtRules(currentOptions);
 
     // Instantiate Columns based on the merged options.
     this.columns = new Columns(currentOptions);
@@ -39,26 +34,6 @@ class Tidy {
   initRule() {
     // The media query's selector to which conditional declarations will be appended.
     this.fullWidthRule = cleanClone(this.rule);
-  }
-
-  /**
-   * Create breakpoint atRules for later use.
-   *
-   * @param  {Object} options The current config options.
-   * @return {Array}         An array of breakpoint atRules.
-   */
-  collectBreakpointAtRules(options) {
-    const { breakpoints } = options;
-
-    return Object.keys(breakpoints).map(breakpoint => (
-      // Create the atRule.
-      postcss.atRule({
-        name: 'media',
-        params: `(min-width: ${breakpoint})`,
-        nodes: [],
-        source: this.rule.source,
-      })
-    ));
   }
 
   /**

--- a/docs/_scss/article.scss
+++ b/docs/_scss/article.scss
@@ -78,11 +78,20 @@
 
   @media (min(md)) {
     /**
-     * The header intro should span 6 columns on medium screens.
+     * The header intro should span 6 columns on medium screens AND large screens.
      *
-     * tidy-span: 6;
+     * Because I am using a breakpoint configuration to set up two distinct
+     * Tidy Columns configurations, the declaration must be re-declared within
+     * the breakpoint to ensure the correct values are used in the calculation.
+     *
+     * Append !tidy to the declaration to automatically duplicate it inside the
+     * configuration's breakpoints.
+     *
+     * When compiling from Sass, you are required to escape the exclamation: \!tidy
+     *
+     * tidy-span: 6 !tidy;
      */
-    tidy-span: 6;
+    tidy-span: 6 \!tidy;
   }
 
   @media (min(lg)) {
@@ -93,16 +102,5 @@
     padding-right: rem(64);
     position: absolute;
     right: 0;
-    /**
-     * Because I am using a breakpoint configuration to set up two distinct
-     * Tidy Columns configurations, the declaration must be re-declared within
-     * the breakpoint to ensure the correct values are used in the calculation.
-     *
-     * Check out the Tidy Columns Wiki for simple `keep-tidy` Sass mixin.
-     * @see https://github.com/goodguyry/postcss-tidy-columns/wiki
-     *
-     * tidy-span: 6;
-     */
-    tidy-span: 6;
   }
 }

--- a/docs/_scss/content.scss
+++ b/docs/_scss/content.scss
@@ -127,26 +127,20 @@
      * the edge of the site, then tack on the edge value to pull the figure to
      * the edge of the site's max-width.
      *
-     * margin-left: calc(tidy-offset(-1) - tidy-var(edge));
+     * When using tidy-* functions in non-width properties, the `-full` version
+     * of the function must be declared in a media query matching the site's
+     * max-width to ensure the static value is calculated based on the site's
+     * max-width rather than `vw` units. Appending the declaration with !tidy
+     * automates this..
+     *
+     * margin-left: calc(tidy-offset(-1) - tidy-var(edge)) !tidy;
      */
-    margin-left: calc(tidy-offset(-2) - tidy-var(edge));
+    margin-left: calc(tidy-offset(-2) - tidy-var(edge)) \!tidy;
     max-width: tidy-var(siteMax);
 
     .content__img {
       margin-bottom: 0;
     }
-  }
-
-  @media (min(full)) {
-    /**
-     * When using tidy-* functions in non-width properties, the `-full` version
-     * of the function must be declared in a media query matching the site's
-     * max-width to ensure the static value is calculated based on the site's
-     * max-width rather than `vw` units.
-     *
-     * margin-left: calc(tidy-offset-full(-2) - tidy-var(edge));
-     */
-    margin-left: calc(tidy-offset-full(-2) - tidy-var(edge));
   }
 }
 
@@ -168,23 +162,17 @@
      * we must include the implied edge value in the offset so the distance is
      * correct.
      *
-     * right: calc(tidy-var(edge) + tidy-offset(1));
-     */
-    right: calc(tidy-var(edge) + tidy-offset(1));
-    // Override the `tidy-span` property from the rule's root.
-    width: auto;
-  }
-
-  @media (min(full)) {
-    /**
      * When using tidy-* functions in non-width properties, the `-full` version
      * of the function must be declared in a media query matching the site's
      * max-width to ensure the static value is calculated based on the site's
-     * max-width rather than `vw` units.
+     * max-width rather than `vw` units. Appending the declaration with !tidy
+     * automates this..
      *
-     * right: calc(tidy-var(edge) + tidy-offset-full(1));
+     * right: calc(tidy-var(edge) + tidy-offset(1)) \!tidy;
      */
-    right: calc(tidy-var(edge) + tidy-offset-full(1));
+    right: calc(tidy-var(edge) + tidy-offset(1)) \!tidy;
+    // Override the `tidy-span` property from the rule's root.
+    width: auto;
   }
 }
 

--- a/docs/_scss/content.scss
+++ b/docs/_scss/content.scss
@@ -6,11 +6,20 @@
   @include auto-margins;
   /**
    * The design calls for the content area to be 6 columns wide (out of 8) on
-   * small screens.
+   * small screens AND large screens.
    *
-   * tidy-span: 6;
+   * Because I am using a breakpoint configuration to set up two distinct
+   * Tidy Columns configurations, the declaration must be re-declared within
+   * the breakpoint to ensure the correct values are used in the calculation.
+   *
+   * Append !tidy to the declaration to automatically duplicate it inside the
+   * configuration's breakpoints.
+   *
+   * When compiling from Sass, you are required to escape the exclamation: \!tidy
+   *
+   * tidy-span: 6 !tidy;
    */
-  tidy-span: 6;
+  tidy-span: 6 \!tidy;
 
   @media (min(lg)) {
     /**
@@ -21,20 +30,6 @@
      * tidy-offset-left: 2;
      */
     tidy-offset-left: 2;
-    /**
-     * The design calls for the content area to be 6 columns wide (out of 12) on
-     * larger screens.
-     *
-     * Because I am using a breakpoint configuration to set up two distinct
-     * Tidy Columns configurations, the declaration must be re-declared within
-     * the breakpoint to ensure the correct values are used in the calculation.
-     *
-     * Check out the Tidy Columns Wiki for simple `keep-tidy` Sass mixin.
-     * @see https://github.com/goodguyry/postcss-tidy-columns/wiki
-     *
-     * tidy-span: 6;
-     */
-      tidy-span: 6;
   }
 }
 

--- a/docs/_scss/site-footer.scss
+++ b/docs/_scss/site-footer.scss
@@ -7,47 +7,39 @@
   font-size: rem(12);
   margin-bottom: rem(10);
   /**
-   * Quick and dirty full-width container.
+   * Quick and dirty, fully-responsive, full-width container.
    *
-   * tidy-span: tidy-var(columns);
+   * Because I am using a breakpoint configuration to set up two distinct
+   * Tidy Columns configurations, the declaration must be re-declared within
+   * the breakpoint to ensure the correct values are used in the calculation.
+   *
+   * Append !tidy to the declaration to automatically duplicate it inside the
+   * configuration's breakpoints.
+   *
+   * When compiling from Sass, you are required to escape the exclamation: \!tidy
+   *
+   * tidy-span: tidy-var(columns) !tidy;
    */
-  tidy-span: tidy-var(columns);
-
-  @media(min(lg)) {
-    /**
-     * Because I am using a breakpoint configuration to set up two distinct
-     * Tidy Columns configurations, the declaration must be re-declared within
-     * the breakpoint to ensure the correct values are used in the calculation.
-     *
-     * Check out the Tidy Columns Wiki for simple `keep-tidy` Sass mixin.
-     * @see https://github.com/goodguyry/postcss-tidy-columns/wiki
-     *
-     * tidy-span: tidy-var(columns);
-     */
-    tidy-span: tidy-var(columns);
-  }
+  tidy-span: tidy-var(columns) \!tidy;
 
   p {
     /**
      * The design calls for the footer content to be offset by 1.5 columns.
      * It happens.
      *
-     * tidy-offset-left: 1.5;
+     * This offset is for all screen sizes.
+     *
+     * Because I am using a breakpoint configuration to set up two distinct
+     * Tidy Columns configurations, the declaration must be re-declared within
+     * the breakpoint to ensure the correct values are used in the calculation.
+     *
+     * Append !tidy to the declaration to automatically duplicate it inside the
+     * configuration's breakpoints.
+     *
+     * When compiling from Sass, you are required to escape the exclamation: \!tidy
+     *
+     * tidy-offset-left: 1.5 !tidy;
      */
-    tidy-offset-left: 1.5;
-
-    @media(min(lg)) {
-      /**
-       * Because I am using a breakpoint configuration to set up two distinct
-       * Tidy Columns configurations, the declaration must be re-declared within
-       * the breakpoint to ensure the correct values are used in the calculation.
-       *
-       * Check out the Tidy Columns Wiki for simple `keep-tidy` Sass mixin.
-       * @see https://github.com/goodguyry/postcss-tidy-columns/wiki
-       *
-       * tidy-offset-left: 1.5;
-       */
-      tidy-offset-left: 1.5;
-    }
+    tidy-offset-left: 1.5 \!tidy;
   }
 }

--- a/docs/_scss/site-header.scss
+++ b/docs/_scss/site-header.scss
@@ -22,33 +22,40 @@
    * Using the `tidy-var()` to get a config value, for no other reason than that
    * it's convenient.
    *
-   * padding: tidy-var(edge) 0;
+   * This padding is the same for all screen sizes.
+   *
+   * Because I am using a breakpoint configuration to set up two distinct
+   * Tidy Columns configurations, the declaration must be re-declared within
+   * the breakpoint to ensure the correct values are used in the calculation.
+   *
+   * Append !tidy to the declaration to automatically duplicate it inside the
+   * configuration's breakpoints.
+   *
+   * When compiling from Sass, you are required to escape the exclamation: \!tidy
+   *
+   * padding: tidy-var(edge) 0 !tidy;
    */
-  padding: tidy-var(edge) 0;
+  padding: tidy-var(edge) 0 \!tidy;
 
   /**
-   * Quick and dirty full-width container.
+   * Quick and dirty, fully-responsive, full-width container.
    *
-   * tidy-span: tidy-var(columns);
+   * Because I am using a breakpoint configuration to set up two distinct
+   * Tidy Columns configurations, the declaration must be re-declared within
+   * the breakpoint to ensure the correct values are used in the calculation.
+   *
+   * Append !tidy to the declaration to automatically duplicate it inside the
+   * configuration's breakpoints.
+   *
+   * When compiling from Sass, you are required to escape the exclamation: \!tidy
+   *
+   * tidy-span: tidy-var(columns) !tidy;
    */
-  tidy-span: tidy-var(columns);
+  tidy-span: tidy-var(columns) \!tidy;
 
   @media (min(lg)) {
     align-items: center;
     flex-wrap: nowrap;
-    /**
-     * Because I am using a breakpoint configuration to set up two distinct
-     * Tidy Columns configurations, the declaration must be re-declared within
-     * the breakpoint to ensure the correct values are used in the calculation.
-     *
-     * Check out the Tidy Columns Wiki for simple `keep-tidy` Sass mixin.
-     * @see https://github.com/goodguyry/postcss-tidy-columns/wiki
-     *
-     * padding: tidy-var(edge) 0;
-     * tidy-span: tidy-var(columns);
-     */
-    padding: tidy-var(edge) 0;
-    tidy-span: tidy-var(columns);
   }
 }
 
@@ -78,26 +85,24 @@
   margin: 0 0 rem(16) 0;
   /**
    * Using the `tidy-var()` to get a config value to keep the button edge
-   * padding consistent with any other horizontal spacing.
+   * padding consistent across screen sizes with any other horizontal spacing.
    *
-   * padding: 0 tidy-var(edge);
+   * Because I am using a breakpoint configuration to set up two distinct
+   * Tidy Columns configurations, the declaration must be re-declared within
+   * the breakpoint to ensure the correct values are used in the calculation.
+   *
+   * Append !tidy to the declaration to automatically duplicate it inside the
+   * configuration's breakpoints.
+   *
+   * When compiling from Sass, you are required to escape the exclamation: \!tidy
+   *
+   * padding: 0 tidy-var(edge) !tidy;
    */
-  padding: 0 tidy-var(edge);
+  padding: 0 tidy-var(edge) \!tidy;
 
   @media (min(lg)) {
     font-size: rem(16);
     margin-bottom: 0;
-    /**
-     * Because I am using a breakpoint configuration to set up two distinct
-     * Tidy Columns configurations, the declaration must be re-declared within
-     * the breakpoint to ensure the correct values are used in the calculation.
-     *
-     * Check out the Tidy Columns Wiki for simple `keep-tidy` Sass mixin.
-     * @see https://github.com/goodguyry/postcss-tidy-columns/wiki
-     *
-     * padding: 0 tidy-var(edge);
-     */
-    padding: 0 tidy-var(edge);
   }
 }
 

--- a/docs/css/main.css
+++ b/docs/css/main.css
@@ -261,35 +261,45 @@ body {
    * Using the `tidy-var()` to get a config value, for no other reason than that
    * it's convenient.
    *
-   * padding: tidy-var(edge) 0;
+   * This padding is the same for all screen sizes.
+   *
+   * Because I am using a breakpoint configuration to set up two distinct
+   * Tidy Columns configurations, the declaration must be re-declared within
+   * the breakpoint to ensure the correct values are used in the calculation.
+   * For such cases, append !tidy to the declaration for it to automatically
+   * be duplicated inside the configuration's breakpoints.
+   *
+   * padding: tidy-var(edge) 0 !tidy;
    */
   padding: 0.75rem 0;
   /**
-   * Quick and dirty full-width container.
+   * Quick and dirty, fully-responsive, full-width container.
    *
-   * tidy-span: tidy-var(columns);
+   * Because I am using a breakpoint configuration to set up two distinct
+   * Tidy Columns configurations, the declaration must be re-declared within
+   * the breakpoint to ensure the correct values are used in the calculation.
+   * For such cases, append !tidy to the declaration for it to automatically
+   * be duplicated inside the configuration's breakpoints.
+   *
+   * tidy-span: tidy-var(columns) !tidy;
    */
   width: calc((((100vw - 0.75rem * 2) / 8 - 0.4375rem) * 8) + 0.5rem * 7);
 }
 
 @media (min-width: 64rem) {
   .site-header__inner {
-    align-items: center;
-    flex-wrap: nowrap;
-    /**
-     * Because I am using a breakpoint configuration to set up two distinct
-     * Tidy Columns configurations, the declaration must be re-declared within
-     * the breakpoint to ensure the correct values are used in the calculation.
-     *
-     * Check out the Tidy Columns Wiki for simple `keep-tidy` Sass mixin.
-     * @see https://github.com/goodguyry/postcss-tidy-columns/wiki
-     *
-     * padding: tidy-var(edge) 0;
-     * tidy-span: tidy-var(columns);
-     */
     padding: 1.875rem 0;
+  }
+  .site-header__inner {
     width: calc((((100vw - 1.875rem * 2) / 12 - 1.1458rem) * 12) + 1.25rem * 11);
     max-width: calc((((80rem - 1.875rem * 2) / 12 - 1.1458rem) * 12) + 1.25rem * 11);
+  }
+}
+
+@media (min-width: 64rem) {
+  .site-header__inner {
+    align-items: center;
+    flex-wrap: nowrap;
   }
 }
 
@@ -323,28 +333,29 @@ body {
   margin: 0 0 1rem 0;
   /**
    * Using the `tidy-var()` to get a config value to keep the button edge
-   * padding consistent with any other horizontal spacing.
+   * padding consistent across screen sizes with any other horizontal spacing.
    *
-   * padding: 0 tidy-var(edge);
+   * Because I am using a breakpoint configuration to set up two distinct
+   * Tidy Columns configurations, the declaration must be re-declared within
+   * the breakpoint to ensure the correct values are used in the calculation.
+   * For such cases, append !tidy to the declaration for it to automatically
+   * be duplicated inside the configuration's breakpoints.
+   *
+   * padding: 0 tidy-var(edge) !tidy;
    */
   padding: 0 0.75rem;
 }
 
 @media (min-width: 64rem) {
   .site-header__toggle {
+    padding: 0 1.875rem;
+  }
+}
+
+@media (min-width: 64rem) {
+  .site-header__toggle {
     font-size: 1rem;
     margin-bottom: 0;
-    /**
-     * Because I am using a breakpoint configuration to set up two distinct
-     * Tidy Columns configurations, the declaration must be re-declared within
-     * the breakpoint to ensure the correct values are used in the calculation.
-     *
-     * Check out the Tidy Columns Wiki for simple `keep-tidy` Sass mixin.
-     * @see https://github.com/goodguyry/postcss-tidy-columns/wiki
-     *
-     * padding: 0 tidy-var(edge);
-     */
-    padding: 0 1.875rem;
   }
 }
 
@@ -487,11 +498,24 @@ body {
 @media (min-width: 48rem) {
   .article-header__intro {
     /**
-     * The header intro should span 6 columns on medium screens.
+     * The header intro should span 6 columns on medium screens AND large screens.
+     *
+     * Because I am using a breakpoint configuration to set up two distinct
+     * Tidy Columns configurations, the declaration must be re-declared within
+     * the breakpoint to ensure the correct values are used in the calculation.
+     * For such cases, append !tidy to the declaration for it to automatically
+     * be duplicated inside the configuration's breakpoints.
      *
      * tidy-span: 6;
      */
     width: calc((((100vw - 0.75rem * 2) / 8 - 0.4375rem) * 6) + 0.5rem * 5);
+  }
+}
+
+@media (min-width: 64rem) {
+  .article-header__intro {
+    width: calc((((100vw - 1.875rem * 2) / 12 - 1.1458rem) * 6) + 1.25rem * 5);
+    max-width: calc((((80rem - 1.875rem * 2) / 12 - 1.1458rem) * 6) + 1.25rem * 5);
   }
 }
 
@@ -504,18 +528,6 @@ body {
     padding-right: 4rem;
     position: absolute;
     right: 0;
-    /**
-     * Because I am using a breakpoint configuration to set up two distinct
-     * Tidy Columns configurations, the declaration must be re-declared within
-     * the breakpoint to ensure the correct values are used in the calculation.
-     *
-     * Check out the Tidy Columns Wiki for simple `keep-tidy` Sass mixin.
-     * @see https://github.com/goodguyry/postcss-tidy-columns/wiki
-     *
-     * tidy-span: 6;
-     */
-    width: calc((((100vw - 1.875rem * 2) / 12 - 1.1458rem) * 6) + 1.25rem * 5);
-    max-width: calc((((80rem - 1.875rem * 2) / 12 - 1.1458rem) * 6) + 1.25rem * 5);
   }
 }
 
@@ -527,11 +539,25 @@ body {
   margin-right: auto;
   /**
    * The design calls for the content area to be 6 columns wide (out of 8) on
-   * small screens.
+   * small screens AND large screens.
    *
-   * tidy-span: 6;
+   * Because I am using a breakpoint configuration to set up two distinct
+   * Tidy Columns configurations, the declaration must be re-declared within
+   * the breakpoint to ensure the correct values are used in the calculation.
+   * For such cases, append !tidy to the declaration for it to automatically
+   * be duplicated inside the configuration's breakpoints.
+   *
+   * When compiling from Sass, you are required to escape the exclamation: \!tidy
+   *
+   * tidy-span: 6 !tidy;
    */
   width: calc((((100vw - 0.75rem * 2) / 8 - 0.4375rem) * 6) + 0.5rem * 5);
+}
+@media (min-width: 64rem) {
+  .content {
+    width: calc((((100vw - 1.875rem * 2) / 12 - 1.1458rem) * 6) + 1.25rem * 5);
+    max-width: calc((((80rem - 1.875rem * 2) / 12 - 1.1458rem) * 6) + 1.25rem * 5);
+  }
 }
 
 @media (min-width: 64rem) {
@@ -544,21 +570,6 @@ body {
      * tidy-offset-left: 2;
      */
     margin-left: calc((((100vw - 1.875rem * 2) / 12 - 1.1458rem) * 2) + 1.25rem * 2);
-    /**
-     * The design calls for the content area to be 6 columns wide (out of 12) on
-     * larger screens.
-     *
-     * Because I am using a breakpoint configuration to set up two distinct
-     * Tidy Columns configurations, the declaration must be re-declared within
-     * the breakpoint to ensure the correct values are used in the calculation.
-     *
-     * Check out the Tidy Columns Wiki for simple `keep-tidy` Sass mixin.
-     * @see https://github.com/goodguyry/postcss-tidy-columns/wiki
-     *
-     * tidy-span: 6;
-     */
-    width: calc((((100vw - 1.875rem * 2) / 12 - 1.1458rem) * 6) + 1.25rem * 5);
-    max-width: calc((((80rem - 1.875rem * 2) / 12 - 1.1458rem) * 6) + 1.25rem * 5);
   }
 }
 
@@ -757,25 +768,20 @@ body {
   font-size: 0.75rem;
   margin-bottom: 0.625rem;
   /**
-   * Quick and dirty full-width container.
+   * Quick and dirty, fully-responsive, full-width container.
    *
-   * tidy-span: tidy-var(columns);
+   * Because I am using a breakpoint configuration to set up two distinct
+   * Tidy Columns configurations, the declaration must be re-declared within
+   * the breakpoint to ensure the correct values are used in the calculation.
+   * For such cases, append !tidy to the declaration for it to automatically
+   * be duplicated inside the configuration's breakpoints.
+   *
+   * tidy-span: tidy-var(columns) !tidy;
    */
   width: calc((((100vw - 0.75rem * 2) / 8 - 0.4375rem) * 8) + 0.5rem * 7);
 }
-
 @media (min-width: 64rem) {
   [role="contentinfo"] {
-    /**
-     * Because I am using a breakpoint configuration to set up two distinct
-     * Tidy Columns configurations, the declaration must be re-declared within
-     * the breakpoint to ensure the correct values are used in the calculation.
-     *
-     * Check out the Tidy Columns Wiki for simple `keep-tidy` Sass mixin.
-     * @see https://github.com/goodguyry/postcss-tidy-columns/wiki
-     *
-     * tidy-span: tidy-var(columns);
-     */
     width: calc((((100vw - 1.875rem * 2) / 12 - 1.1458rem) * 12) + 1.25rem * 11);
     max-width: calc((((80rem - 1.875rem * 2) / 12 - 1.1458rem) * 12) + 1.25rem * 11);
   }
@@ -786,23 +792,21 @@ body {
      * The design calls for the footer content to be offset by 1.5 columns.
      * It happens.
      *
-     * tidy-offset-left: 1.5;
+     * This ofset is for all screen sizes.
+     *
+     * Because I am using a breakpoint configuration to set up two distinct
+     * Tidy Columns configurations, the declaration must be re-declared within
+     * the breakpoint to ensure the correct values are used in the calculation.
+     * For such cases, append !tidy to the declaration for it to automatically
+     * be duplicated inside the configuration's breakpoints.
+     *
+     * tidy-offset-left: 1.5 !tidy;
      */
   margin-left: calc((((100vw - 0.75rem * 2) / 8 - 0.4375rem) * 1.5) + 0.5rem);
 }
 
 @media (min-width: 64rem) {
   [role="contentinfo"] p {
-    /**
-       * Because I am using a breakpoint configuration to set up two distinct
-       * Tidy Columns configurations, the declaration must be re-declared within
-       * the breakpoint to ensure the correct values are used in the calculation.
-       *
-       * Check out the Tidy Columns Wiki for simple `keep-tidy` Sass mixin.
-       * @see https://github.com/goodguyry/postcss-tidy-columns/wiki
-       *
-       * tidy-offset-left: 1.5;
-       */
     margin-left: calc((((100vw - 1.875rem * 2) / 12 - 1.1458rem) * 1.5) + 1.25rem);
   }
 }

--- a/docs/css/main.css
+++ b/docs/css/main.css
@@ -266,8 +266,11 @@ body {
    * Because I am using a breakpoint configuration to set up two distinct
    * Tidy Columns configurations, the declaration must be re-declared within
    * the breakpoint to ensure the correct values are used in the calculation.
-   * For such cases, append !tidy to the declaration for it to automatically
-   * be duplicated inside the configuration's breakpoints.
+   *
+   * Append !tidy to the declaration to automatically duplicate it inside the
+   * configuration's breakpoints.
+   *
+   * When compiling from Sass, you are required to escape the exclamation: \!tidy
    *
    * padding: tidy-var(edge) 0 !tidy;
    */
@@ -278,8 +281,11 @@ body {
    * Because I am using a breakpoint configuration to set up two distinct
    * Tidy Columns configurations, the declaration must be re-declared within
    * the breakpoint to ensure the correct values are used in the calculation.
-   * For such cases, append !tidy to the declaration for it to automatically
-   * be duplicated inside the configuration's breakpoints.
+   *
+   * Append !tidy to the declaration to automatically duplicate it inside the
+   * configuration's breakpoints.
+   *
+   * When compiling from Sass, you are required to escape the exclamation: \!tidy
    *
    * tidy-span: tidy-var(columns) !tidy;
    */
@@ -288,11 +294,14 @@ body {
 
 @media (min-width: 64rem) {
   .site-header__inner {
-    padding: 1.875rem 0;
-  }
-  .site-header__inner {
     width: calc((((100vw - 1.875rem * 2) / 12 - 1.1458rem) * 12) + 1.25rem * 11);
     max-width: calc((((80rem - 1.875rem * 2) / 12 - 1.1458rem) * 12) + 1.25rem * 11);
+  }
+}
+
+@media (min-width: 64rem) {
+  .site-header__inner {
+    padding: 1.875rem 0;
   }
 }
 
@@ -338,8 +347,11 @@ body {
    * Because I am using a breakpoint configuration to set up two distinct
    * Tidy Columns configurations, the declaration must be re-declared within
    * the breakpoint to ensure the correct values are used in the calculation.
-   * For such cases, append !tidy to the declaration for it to automatically
-   * be duplicated inside the configuration's breakpoints.
+   *
+   * Append !tidy to the declaration to automatically duplicate it inside the
+   * configuration's breakpoints.
+   *
+   * When compiling from Sass, you are required to escape the exclamation: \!tidy
    *
    * padding: 0 tidy-var(edge) !tidy;
    */
@@ -503,10 +515,13 @@ body {
      * Because I am using a breakpoint configuration to set up two distinct
      * Tidy Columns configurations, the declaration must be re-declared within
      * the breakpoint to ensure the correct values are used in the calculation.
-     * For such cases, append !tidy to the declaration for it to automatically
-     * be duplicated inside the configuration's breakpoints.
      *
-     * tidy-span: 6;
+     * Append !tidy to the declaration to automatically duplicate it inside the
+     * configuration's breakpoints.
+     *
+     * When compiling from Sass, you are required to escape the exclamation: \!tidy
+     *
+     * tidy-span: 6 !tidy;
      */
     width: calc((((100vw - 0.75rem * 2) / 8 - 0.4375rem) * 6) + 0.5rem * 5);
   }
@@ -544,8 +559,9 @@ body {
    * Because I am using a breakpoint configuration to set up two distinct
    * Tidy Columns configurations, the declaration must be re-declared within
    * the breakpoint to ensure the correct values are used in the calculation.
-   * For such cases, append !tidy to the declaration for it to automatically
-   * be duplicated inside the configuration's breakpoints.
+   *
+   * Append !tidy to the declaration to automatically duplicate it inside the
+   * configuration's breakpoints.
    *
    * When compiling from Sass, you are required to escape the exclamation: \!tidy
    *
@@ -773,8 +789,11 @@ body {
    * Because I am using a breakpoint configuration to set up two distinct
    * Tidy Columns configurations, the declaration must be re-declared within
    * the breakpoint to ensure the correct values are used in the calculation.
-   * For such cases, append !tidy to the declaration for it to automatically
-   * be duplicated inside the configuration's breakpoints.
+   *
+   * Append !tidy to the declaration to automatically duplicate it inside the
+   * configuration's breakpoints.
+   *
+   * When compiling from Sass, you are required to escape the exclamation: \!tidy
    *
    * tidy-span: tidy-var(columns) !tidy;
    */
@@ -792,13 +811,16 @@ body {
      * The design calls for the footer content to be offset by 1.5 columns.
      * It happens.
      *
-     * This ofset is for all screen sizes.
+     * This offset is for all screen sizes.
      *
      * Because I am using a breakpoint configuration to set up two distinct
      * Tidy Columns configurations, the declaration must be re-declared within
      * the breakpoint to ensure the correct values are used in the calculation.
-     * For such cases, append !tidy to the declaration for it to automatically
-     * be duplicated inside the configuration's breakpoints.
+     *
+     * Append !tidy to the declaration to automatically duplicate it inside the
+     * configuration's breakpoints.
+     *
+     * When compiling from Sass, you are required to escape the exclamation: \!tidy
      *
      * tidy-offset-left: 1.5 !tidy;
      */

--- a/docs/css/main.css
+++ b/docs/css/main.css
@@ -702,7 +702,13 @@ body {
      * the edge of the site, then tack on the edge value to pull the figure to
      * the edge of the site's max-width.
      *
-     * margin-left: calc(tidy-offset(-1) - tidy-var(edge));
+     * When using tidy-* functions in non-width properties, the `-full` version
+     * of the function must be declared in a media query matching the site's
+     * max-width to ensure the static value is calculated based on the site's
+     * max-width rather than `vw` units. Appending the declaration with !tidy
+     * automates this..
+     *
+     * margin-left: calc(tidy-offset(-1) - tidy-var(edge)) !tidy;
      */
     margin-left: calc(((((100vw - 1.875rem * 2) / 12 - 1.1458rem) * -2) + 1.25rem * -2) - 1.875rem);
     max-width: 80rem;
@@ -714,14 +720,6 @@ body {
 
 @media (min-width: 80rem) {
   .content__figure--fullwidth {
-    /**
-     * When using tidy-* functions in non-width properties, the `-full` version
-     * of the function must be declared in a media query matching the site's
-     * max-width to ensure the static value is calculated based on the site's
-     * max-width rather than `vw` units.
-     *
-     * margin-left: calc(tidy-offset-full(-2) - tidy-var(edge));
-     */
     margin-left: calc(((((80rem - 1.875rem * 2) / 12 - 1.1458rem) * -2) + 1.25rem * -2) - 1.875rem);
   }
 }
@@ -747,7 +745,13 @@ body {
      * we must include the implied edge value in the offset so the distance is
      * correct.
      *
-     * right: calc(tidy-var(edge) + tidy-offset(1));
+     * When using tidy-* functions in non-width properties, the `-full` version
+     * of the function must be declared in a media query matching the site's
+     * max-width to ensure the static value is calculated based on the site's
+     * max-width rather than `vw` units. Appending the declaration with !tidy
+     * automates this..
+     *
+     * right: calc(tidy-var(edge) + tidy-offset(1)) \!tidy;
      */
     right: calc(1.875rem + (((100vw - 1.875rem * 2) / 12 - 1.1458rem) + 1.25rem));
     width: auto;
@@ -756,14 +760,6 @@ body {
 
 @media (min-width: 80rem) {
   .content__figcaption--fullwidth {
-    /**
-     * When using tidy-* functions in non-width properties, the `-full` version
-     * of the function must be declared in a media query matching the site's
-     * max-width to ensure the static value is calculated based on the site's
-     * max-width rather than `vw` units.
-     *
-     * right: calc(tidy-var(edge) + tidy-offset-full(1));
-     */
     right: calc(1.875rem + (((80rem - 1.875rem * 2) / 12 - 1.1458rem) + 1.25rem));
   }
 }

--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ module.exports = postcss.plugin(
     root.walkRules((rule) => {
       const tidy = new Tidy(rule, globalOptions);
 
-      // // Duplicate declarations containing the `!tidy` rule.
+      // Duplicate declarations containing the `!tidy` rule.
       rule.walkDecls((declaration) => {
         if (/!tidy/.test(declaration.value)) {
           tidyPropagation(declaration, tidy, root);

--- a/index.js
+++ b/index.js
@@ -25,7 +25,7 @@ module.exports = postcss.plugin(
       // Duplicate declarations containing the `!tidy` rule.
       rule.walkDecls((declaration) => {
         if (/!tidy/.test(declaration.value)) {
-          tidyPropagation(declaration, tidy, root);
+          tidyPropagation(declaration, tidy);
         }
       });
 

--- a/test/sourcemap/propagation.css
+++ b/test/sourcemap/propagation.css
@@ -1,0 +1,3 @@
+div {
+	tidy-span: 2 !tidy;
+}

--- a/test/sourcemap/propagation.generated.css
+++ b/test/sourcemap/propagation.generated.css
@@ -1,0 +1,16 @@
+div {
+	width: calc((((100vw - 0.625rem * 2) / 12 - 1.1458rem) * 2) + 1.25rem);
+}
+
+@media (min-width: 768px) {
+  div {
+    width: calc((((100vw - 0.625rem * 2) / 12 - 0.5859rem) * 2) + 0.625rem);
+  }
+}
+
+@media (min-width: 1024px) {
+  div {
+    width: calc((((100vw - 0.625rem * 2) / 12 - 0.5859rem) * 2) + 1.25rem);
+    max-width: calc((((90rem - 0.625rem * 2) / 12 - 0.5859rem) * 2) + 1.25rem);
+  }
+}

--- a/test/sourcemap/propagation.generated.css
+++ b/test/sourcemap/propagation.generated.css
@@ -1,5 +1,5 @@
 div {
-	width: calc((((100vw - 0.625rem * 2) / 12 - 1.1458rem) * 2) + 1.25rem);
+  width: calc((((100vw - 0.625rem * 2) / 12 - 1.1458rem) * 2) + 1.25rem);
 }
 
 @media (min-width: 768px) {

--- a/test/sourcemap/sourcemap.js
+++ b/test/sourcemap/sourcemap.js
@@ -1,6 +1,6 @@
 /* eslint-disable max-len */
 const path = require('path');
-const { typical } = require('../sharedConfigs');
+const { typical, typicalWithBreakpoints } = require('../sharedConfigs');
 
 module.exports = [
   {
@@ -101,6 +101,26 @@ module.exports = [
     fixtures: {
       from: path.join(__dirname, 'function-span.css'),
       to: path.join(__dirname, 'function-span.generated.css'),
+    },
+  },
+  {
+    description: 'Sourcemap fixture: propagation.css',
+    options: typicalWithBreakpoints,
+    map: {
+      version: 3,
+      sources: [
+        'propagation.css',
+      ],
+      names: [],
+      mappings: 'AAAA;CACC,uEAAmB;CACnB;AAFD;CAAA;EACC,wEAAmB;EACnB;CAAA;AAFD;CAAA;EACC,wEAAmB;EAAnB,4EAAmB;EACnB;CAAA',
+      file: 'propagation.generated.css',
+      sourcesContent: [
+        'div {\n\ttidy-span: 2 !tidy;\n}\n',
+      ],
+    },
+    fixtures: {
+      from: path.join(__dirname, 'propagation.css'),
+      to: path.join(__dirname, 'propagation.generated.css'),
     },
   },
 ];

--- a/test/tidy-propagation.test.js
+++ b/test/tidy-propagation.test.js
@@ -1,6 +1,7 @@
 /* eslint-disable max-len */
 const postcss = require('postcss');
 const run = require('.');
+const Tidy = require('../Tidy');
 const { typicalWithBreakpoints } = require('./sharedConfigs');
 const { tidyPropagation } = require('../tidy-propagation');
 
@@ -12,11 +13,15 @@ const runShorthandTest = (input, output, options = {}) => (
   run(input, output, options, postcss.plugin(
     'shorthand-props-test',
     () => function process(root) {
-      root.walkDecls((declaration) => {
-        if (/!tidy/.test(declaration.value)) {
-          // Pass in a mock Tidy object.
-          tidyPropagation(declaration, { columns: { options } }, root);
-        }
+      root.walkRules((rule) => {
+        const tidy = new Tidy(rule, options);
+
+        root.walkDecls((declaration) => {
+          if (/!tidy/.test(declaration.value)) {
+            // Pass in a mock Tidy object.
+            tidyPropagation(declaration, tidy, root);
+          }
+        });
       });
     },
   ))

--- a/test/tidy-propagation.test.js
+++ b/test/tidy-propagation.test.js
@@ -28,7 +28,7 @@ const runShorthandTest = (input, output, options = {}) => (
 );
 
 /**
- * Clean and trim shorthand property values.
+ * Duplicate properties with a !tidy rule.
  */
 describe('The `!tidy` signals a declaration should be duplicated inside any configured breakpoints', () => {
   test(
@@ -119,6 +119,9 @@ describe('The `!tidy` signals a declaration should be duplicated inside any conf
   );
 });
 
+/**
+ * Find the siteMax option value, if any.
+ */
 describe('getSiteMax properly retrieves the relevant siteMax value', () => {
   test('Single siteMax in root is returned', () => {
     const options = { siteMax: '90rem' };

--- a/test/tidy-propagation.test.js
+++ b/test/tidy-propagation.test.js
@@ -3,7 +3,7 @@ const postcss = require('postcss');
 const run = require('.');
 const Tidy = require('../Tidy');
 const { typicalWithBreakpoints } = require('./sharedConfigs');
-const { tidyPropagation } = require('../tidy-propagation');
+const { tidyPropagation, getSiteMax } = require('../tidy-propagation');
 
 /**
  * Create a test plugin to replace shorthand properties. Running a test plugin
@@ -117,4 +117,56 @@ describe('The `!tidy` signals a declaration should be duplicated inside any conf
       typicalWithBreakpoints,
     ),
   );
+});
+
+describe('getSiteMax properly retrieves the relevant siteMax value', () => {
+  test('Single siteMax in root is returned', () => {
+    const options = { siteMax: '90rem' };
+    expect(getSiteMax(options)).toEqual('90rem');
+  });
+
+  test('Single siteMax in a breakpoint', () => {
+    const options = {
+      breakpoints: {
+        '100px': {
+          siteMax: '64rem',
+        },
+      },
+    };
+    expect(getSiteMax(options)).toEqual('64rem');
+  });
+
+  test('Multiple siteMax values; only the last is returned', () => {
+    const options = {
+      siteMax: '20rem',
+      breakpoints: {
+        '100px': {
+          siteMax: '64rem',
+        },
+        '900px': {
+          siteMax: '90rem',
+        },
+      },
+    };
+    expect(getSiteMax(options)).toEqual('90rem');
+  });
+
+  test('Single siteMax value returned, with breakpoints ignored', () => {
+    const options = {
+      siteMax: '20rem',
+      breakpoints: {
+        '100px': {
+          columns: 12,
+        },
+        '900px': {
+          gap: '1.25rem',
+        },
+      },
+    };
+    expect(getSiteMax(options)).toEqual('20rem');
+  });
+
+  test('No siteMax to be found', () => {
+    expect(getSiteMax({})).toBeFalsy();
+  });
 });

--- a/test/tidy-propagation.test.js
+++ b/test/tidy-propagation.test.js
@@ -32,7 +32,7 @@ const runShorthandTest = (input, output, options = {}) => (
  */
 describe('The `!tidy` signals a declaration should be duplicated inside any configured breakpoints', () => {
   test(
-    'A property declaration including the `!tidy` rule is duplicated as expected',
+    'A property declaration is duplicated as expected',
     () => runShorthandTest(
       'div { tidy-span: 3 !tidy; }',
       `div { tidy-span: 3; }
@@ -45,7 +45,7 @@ describe('The `!tidy` signals a declaration should be duplicated inside any conf
   );
 
   test(
-    'A function declaration including the `!tidy` rule is duplicated as expected',
+    'A function declaration is duplicated as expected',
     () => runShorthandTest(
       'div { width: calc(tidy-span(3) + 2rem) !tidy; }',
       `div { width: calc(tidy-span(3) + 2rem); }
@@ -58,7 +58,7 @@ describe('The `!tidy` signals a declaration should be duplicated inside any conf
   );
 
   test(
-    'A non-tidy declaration including the `!tidy` rule is duplicated as expected',
+    'A non-tidy declaration is duplicated as expected',
     () => runShorthandTest(
       'div { width: 14px !tidy; }',
       `div { width: 14px; }
@@ -66,6 +66,15 @@ describe('The `!tidy` signals a declaration should be duplicated inside any conf
  div { width: 14px; } }
 @media (min-width: 1024px) {
  div { width: 14px; } }`,
+      typicalWithBreakpoints,
+    ),
+  );
+
+  test(
+    'A tidy declaration inside a media query is duplicated as expected',
+    () => runShorthandTest(
+      '@media (min-width: 768px) { div { tidy-span: 3 !tidy; } }',
+      '@media (min-width: 768px) { div { tidy-span: 3; } } @media (min-width: 1024px) { div { tidy-span: 3; } }',
       typicalWithBreakpoints,
     ),
   );

--- a/test/tidy-propagation.test.js
+++ b/test/tidy-propagation.test.js
@@ -65,7 +65,9 @@ describe('The `!tidy` signals a declaration should be duplicated inside any conf
 @media (min-width: 768px) {
  div { width: calc(tidy-span(3) + 2rem); } }
 @media (min-width: 1024px) {
- div { width: calc(tidy-span(3) + 2rem); } }`,
+ div { width: calc(tidy-span(3) + 2rem); } }
+@media (min-width: 90rem) {
+ div { width: calc(tidy-span-full(3) + 2rem); } }`,
       typicalWithBreakpoints,
     ),
   );
@@ -97,6 +99,21 @@ describe('The `!tidy` signals a declaration should be duplicated inside any conf
     () => runShorthandTest(
       '@media (max-width: 768px) { div { tidy-span: 3 !tidy; } }',
       '@media (max-width: 768px) { div { tidy-span: 3; } }',
+      typicalWithBreakpoints,
+    ),
+  );
+
+  test(
+    'Adds tidy-offset-full() when a !tidy declaration contains tidy-offset()',
+    () => runShorthandTest(
+      'div { width: calc(tidy-offset(3) + 2rem) !tidy; }',
+      `div { width: calc(tidy-offset(3) + 2rem); }
+@media (min-width: 768px) {
+ div { width: calc(tidy-offset(3) + 2rem); } }
+@media (min-width: 1024px) {
+ div { width: calc(tidy-offset(3) + 2rem); } }
+@media (min-width: 90rem) {
+ div { width: calc(tidy-offset-full(3) + 2rem); } }`,
       typicalWithBreakpoints,
     ),
   );

--- a/test/tidy-propagation.test.js
+++ b/test/tidy-propagation.test.js
@@ -78,4 +78,13 @@ describe('The `!tidy` signals a declaration should be duplicated inside any conf
       typicalWithBreakpoints,
     ),
   );
+
+  test(
+    'Ignores declaration inside max-width media query',
+    () => runShorthandTest(
+      '@media (max-width: 768px) { div { tidy-span: 3 !tidy; } }',
+      '@media (max-width: 768px) { div { tidy-span: 3; } }',
+      typicalWithBreakpoints,
+    ),
+  );
 });

--- a/test/tidy-propagation.test.js
+++ b/test/tidy-propagation.test.js
@@ -1,0 +1,67 @@
+/* eslint-disable max-len */
+const postcss = require('postcss');
+const run = require('.');
+const { typicalWithBreakpoints } = require('./sharedConfigs');
+const { tidyPropagation } = require('../tidy-propagation');
+
+/**
+ * Create a test plugin to replace shorthand properties. Running a test plugin
+ * limits the scope, which prevents any other features of the plugin from running.
+ */
+const runShorthandTest = (input, output, options = {}) => (
+  run(input, output, options, postcss.plugin(
+    'shorthand-props-test',
+    () => function process(root) {
+      root.walkDecls((declaration) => {
+        if (/!tidy/.test(declaration.value)) {
+          // Pass in a mock Tidy object.
+          tidyPropagation(declaration, { columns: { options } }, root);
+        }
+      });
+    },
+  ))
+);
+
+/**
+ * Clean and trim shorthand property values.
+ */
+describe('The `!tidy` signals a declaration should be duplicated inside any configured breakpoints', () => {
+  test(
+    'A property declaration including the `!tidy` rule is duplicated as expected',
+    () => runShorthandTest(
+      'div { tidy-span: 3 !tidy; }',
+      `div { tidy-span: 3; }
+@media (min-width: 768px) {
+ div { tidy-span: 3; } }
+@media (min-width: 1024px) {
+ div { tidy-span: 3; } }`,
+      typicalWithBreakpoints,
+    ),
+  );
+
+  test(
+    'A function declaration including the `!tidy` rule is duplicated as expected',
+    () => runShorthandTest(
+      'div { width: calc(tidy-span(3) + 2rem) !tidy; }',
+      `div { width: calc(tidy-span(3) + 2rem); }
+@media (min-width: 768px) {
+ div { width: calc(tidy-span(3) + 2rem); } }
+@media (min-width: 1024px) {
+ div { width: calc(tidy-span(3) + 2rem); } }`,
+      typicalWithBreakpoints,
+    ),
+  );
+
+  test(
+    'A non-tidy declaration including the `!tidy` rule is duplicated as expected',
+    () => runShorthandTest(
+      'div { width: 14px !tidy; }',
+      `div { width: 14px; }
+@media (min-width: 768px) {
+ div { width: 14px; } }
+@media (min-width: 1024px) {
+ div { width: 14px; } }`,
+      typicalWithBreakpoints,
+    ),
+  );
+});

--- a/test/tidy-propagation.test.js
+++ b/test/tidy-propagation.test.js
@@ -1,4 +1,4 @@
-/* eslint-disable max-len */
+/* eslint-disable max-len, no-useless-escape */
 const postcss = require('postcss');
 const run = require('.');
 const Tidy = require('../Tidy');
@@ -35,6 +35,19 @@ describe('The `!tidy` signals a declaration should be duplicated inside any conf
     'A property declaration is duplicated as expected',
     () => runShorthandTest(
       'div { tidy-span: 3 !tidy; }',
+      `div { tidy-span: 3; }
+@media (min-width: 768px) {
+ div { tidy-span: 3; } }
+@media (min-width: 1024px) {
+ div { tidy-span: 3; } }`,
+      typicalWithBreakpoints,
+    ),
+  );
+
+  test(
+    'A property declaration with escaped ! (\!tidy) is duplicated as expected',
+    () => runShorthandTest(
+      'div { tidy-span: 3 \!tidy; }',
       `div { tidy-span: 3; }
 @media (min-width: 768px) {
  div { tidy-span: 3; } }

--- a/test/tidy-propagation.test.js
+++ b/test/tidy-propagation.test.js
@@ -18,7 +18,6 @@ const runShorthandTest = (input, output, options = {}) => (
 
         root.walkDecls((declaration) => {
           if (/!tidy/.test(declaration.value)) {
-            // Pass in a mock Tidy object.
             tidyPropagation(declaration, tidy, root);
           }
         });

--- a/tidy-propagation.js
+++ b/tidy-propagation.js
@@ -1,46 +1,44 @@
-const postcss = require('postcss');
 const cleanClone = require('./lib/cleanClone');
+const getObjectByProperty = require('./lib/getObjectByProperty');
 
 function tidyPropagation(declaration, tidy, root) {
-  const { columns: { options: { breakpoints } } } = tidy;
+  const { atRules, columns: { options: { breakpoints } } } = tidy;
   const rule = declaration.parent;
 
   // Reverse the breakpoints to make sure they're inserted in the correct order.
   Object.keys(breakpoints).reverse().forEach((breakpoint) => {
-    // Clone the declaration without `!tidy`.
-    const cleanDecl = cleanClone(
+    const atRule = getObjectByProperty(atRules, `(min-width: ${breakpoint})`, 'params');
+
+    if (undefined !== atRule) {
+      // Clone the declaration without `!tidy`.
+      const cleanDecl = cleanClone(
+        declaration,
+        {
+          declaration: declaration.prop,
+          value: declaration.value.replace(/\s?!tidy/, ''),
+        },
+      );
+
+      // Clone the rule and add the cloned declaration.
+      const newRule = cleanClone(rule);
+      newRule.append(cleanDecl);
+
+      // @todo Need to ensure declarations within atrules are applied as expected
+
+      atRule.append(newRule);
+
+      root.insertAfter(rule, atRule);
+    }
+
+    // Replace the declaration with `!tidy` clipped off.
+    declaration.replaceWith(cleanClone(
       declaration,
       {
         declaration: declaration.prop,
         value: declaration.value.replace(/\s?!tidy/, ''),
       },
-    );
-
-    // Clone the rule and add the cloned declaration.
-    const newRule = cleanClone(rule);
-    newRule.append(cleanDecl);
-
-    // @todo Need to ensure declarations within atrules are applied as expected
-
-    // Create the atRule and append the rule.
-    const breakpointAtRule = postcss.atRule({
-      name: 'media',
-      params: `(min-width: ${breakpoint})`,
-      nodes: [],
-      source: rule.source,
-    }).append(newRule);
-
-    root.insertAfter(rule, breakpointAtRule);
+    ));
   });
-
-  // Replace the declaration with `!tidy` clipped off.
-  declaration.replaceWith(cleanClone(
-    declaration,
-    {
-      declaration: declaration.prop,
-      value: declaration.value.replace(/\s?!tidy/, ''),
-    },
-  ));
 }
 
 module.exports = {

--- a/tidy-propagation.js
+++ b/tidy-propagation.js
@@ -30,7 +30,7 @@ function tidyPropagation(declaration, tidy, root) {
         declaration,
         {
           declaration: declaration.prop,
-          value: declaration.value.replace(/\s?!tidy/, ''),
+          value: declaration.value.replace(/\s?\\?!tidy/, ''),
         },
       );
 
@@ -54,7 +54,7 @@ function tidyPropagation(declaration, tidy, root) {
       declaration,
       {
         declaration: declaration.prop,
-        value: declaration.value.replace(/\s?!tidy/, ''),
+        value: declaration.value.replace(/\s?\\?!tidy/, ''),
       },
     ));
   });

--- a/tidy-propagation.js
+++ b/tidy-propagation.js
@@ -4,6 +4,50 @@ const { parseAtruleParams } = require('./lib/parseAtruleParams');
 const compareStrings = require('./lib/compareStrings');
 
 /**
+ * Pattern to match `tidy-*` functions in declaration values.
+ *
+ * @type {RegExp}
+ */
+const FUNCTION_REGEX = /tidy-(span|offset)(-full)?\(([\d.-]+)\)/;
+
+/**
+ * Get the siteMax definition from the options object.
+ *
+ * @param  {Object} options The plugin options.
+ * @return {String|Boolean} The siteMax definition, or false if there is none.
+ */
+function getSiteMax(options) {
+  const { siteMax, breakpoints } = options;
+  const collectedValues = [];
+
+  // Push any root definition to the collected values.
+  if (undefined !== siteMax) {
+    collectedValues.push(siteMax);
+  }
+
+  // Get any definitions within the breakpoints.
+  if (undefined !== breakpoints) {
+    const breakpointKeys = Object.keys(breakpoints);
+
+    if (0 < breakpointKeys.length) {
+      const siteMaxValues = breakpointKeys.reduce((acc, breakpoint) => {
+        if (undefined !== breakpoints[breakpoint].siteMax) {
+          return [...acc, breakpoints[breakpoint].siteMax];
+        }
+
+        return acc;
+      }, collectedValues);
+
+      // We only want the last definition.
+      return siteMaxValues.pop();
+    }
+  }
+
+  // No siteMax defined.
+  return false;
+}
+
+/**
  * Duplicate declarations containing `!tidy` into breakpoints corresponding to
  * the plugin configuration.
  *
@@ -11,7 +55,11 @@ const compareStrings = require('./lib/compareStrings');
  * @param {Object} tidy        An instance of the Tidy class.
  */
 function tidyPropagation(declaration, tidy) {
-  const { columns: { options: { breakpoints } } } = tidy;
+  const { columns: { options } } = tidy;
+  const { breakpoints } = options;
+  const siteMax = getSiteMax(options);
+
+  // Containers.
   const rule = declaration.parent;
   const root = declaration.root();
 
@@ -46,6 +94,41 @@ function tidyPropagation(declaration, tidy) {
     breakpointKeys = breakpointKeys.filter(breakpoint => -1 === compareStrings(value, breakpoint));
   }
 
+  /**
+   * The siteMax-width atRule.
+   * Contains full-width margin offset declarations.
+   *
+   * @todo only create this if siteMax is found.
+   */
+  const fullWidthAtRule = postcss.atRule({
+    name: 'media',
+    params: `(min-width: ${siteMax})`,
+    nodes: [],
+    source: rule.source,
+  });
+
+  if (FUNCTION_REGEX.test(declaration.value)) {
+    /**
+     * match:    The full function expression.
+     * slug:     One of either `span` or `offset`.
+     * modifier: One of either `undefined` or `-full`.
+     * value:    The function's argument.
+     */
+    const [match, slug, modifier, functionValue] = declaration.value.match(FUNCTION_REGEX);
+    if (undefined === modifier) {
+      // Clone the rule and add the cloned declaration.
+      const newRule = cleanClone(rule);
+
+      newRule.append(cleanDecl.clone({
+        value: declaration.value
+          .replace(match, `tidy-${slug}-full(${functionValue})`)
+          .replace(/\s?\\?!tidy/, ''),
+      }));
+
+      fullWidthAtRule.append(newRule);
+    }
+  }
+
   // Collect media queries containing the declaration.
   const atRules = breakpointKeys.reduce((acc, breakpoint) => {
     if ('max' !== minMax) {
@@ -68,6 +151,10 @@ function tidyPropagation(declaration, tidy) {
 
     return acc;
   }, []);
+
+  if (false !== siteMax && 0 < fullWidthAtRule.nodes.length) {
+    atRules.push(fullWidthAtRule);
+  }
 
   // Insert the media query
   if ('atrule' === rule.parent.type) {

--- a/tidy-propagation.js
+++ b/tidy-propagation.js
@@ -9,24 +9,22 @@ function tidyPropagation(declaration, tidy, root) {
   let breakpointKeys = Object.keys(breakpoints);
 
   // Handle parent atRule.
-  if ('atrule' === rule.parent.type) {
-    const [atRuleParams] = parseAtruleParams(rule.parent.params);
-    const { minMax, value } = atRuleParams;
+  const hasAtRuleParent = 'atrule' === rule.parent.type;
+  const [atRuleParams] = hasAtRuleParent
+    ? parseAtruleParams(rule.parent.params)
+    : [{}];
+  const { minMax, value } = atRuleParams;
 
-    // Ignore max-width breakpoints.
-    if ('min' === minMax) {
-      // Rebuild breakpointKeys array without those that won't apply.
-      breakpointKeys = breakpointKeys.filter(breakpoint => (
-        -1 === compareStrings(value, breakpoint)
-      ));
-    }
+  // Filter out breakpoint values that don't apply; ignore max-width breakpoints.
+  if (hasAtRuleParent && 'min' === minMax) {
+    breakpointKeys = breakpointKeys.filter(breakpoint => -1 === compareStrings(value, breakpoint));
   }
 
   // Reverse the breakpoints to make sure they're inserted in the correct order.
   breakpointKeys.reverse().forEach((breakpoint) => {
     const atRule = getObjectByProperty(atRules, `(min-width: ${breakpoint})`, 'params');
 
-    if (undefined !== atRule) {
+    if (undefined !== atRule && 'max' !== minMax) {
       // Clone the declaration without `!tidy`.
       const cleanDecl = cleanClone(
         declaration,

--- a/tidy-propagation.js
+++ b/tidy-propagation.js
@@ -20,18 +20,18 @@ function tidyPropagation(declaration, tidy) {
     breakpointKeys = breakpointKeys.filter(breakpoint => -1 === compareStrings(value, breakpoint));
   }
 
+  // Clone the declaration without `!tidy`.
+  const cleanDecl = cleanClone(
+    declaration,
+    {
+      declaration: declaration.prop,
+      value: declaration.value.replace(/\s?\\?!tidy/, ''),
+    },
+  );
+
   // Reverse the breakpoints to make sure they're inserted in the correct order.
   const atRules = breakpointKeys.reduce((acc, breakpoint) => {
     if ('max' !== minMax) {
-      // Clone the declaration without `!tidy`.
-      const cleanDecl = cleanClone(
-        declaration,
-        {
-          declaration: declaration.prop,
-          value: declaration.value.replace(/\s?\\?!tidy/, ''),
-        },
-      );
-
       const atRule = postcss.atRule({
         name: 'media',
         params: `(min-width: ${breakpoint})`,
@@ -41,7 +41,7 @@ function tidyPropagation(declaration, tidy) {
 
       // Clone the rule and add the cloned declaration.
       const newRule = cleanClone(rule);
-      newRule.append(cleanDecl);
+      newRule.append(cleanDecl.clone());
       atRule.append(newRule);
 
       return [...acc, atRule];
@@ -62,13 +62,7 @@ function tidyPropagation(declaration, tidy) {
   }
 
   // Replace the declaration with `!tidy` clipped off.
-  declaration.replaceWith(cleanClone(
-    declaration,
-    {
-      declaration: declaration.prop,
-      value: declaration.value.replace(/\s?\\?!tidy/, ''),
-    },
-  ));
+  declaration.replaceWith(cleanDecl.clone());
 }
 
 module.exports = {

--- a/tidy-propagation.js
+++ b/tidy-propagation.js
@@ -29,22 +29,20 @@ function getSiteMax(options) {
   if (undefined !== breakpoints) {
     const breakpointKeys = Object.keys(breakpoints);
 
-    if (0 < breakpointKeys.length) {
-      const siteMaxValues = breakpointKeys.reduce((acc, breakpoint) => {
-        if (undefined !== breakpoints[breakpoint].siteMax) {
-          return [...acc, breakpoints[breakpoint].siteMax];
-        }
+    const siteMaxValues = breakpointKeys.reduce((acc, breakpoint) => {
+      if (undefined !== breakpoints[breakpoint].siteMax) {
+        return [...acc, breakpoints[breakpoint].siteMax];
+      }
 
-        return acc;
-      }, collectedValues);
+      return acc;
+    }, collectedValues);
 
-      // We only want the last definition.
-      return siteMaxValues.pop();
-    }
+    // We only want the last definition.
+    return siteMaxValues.pop();
   }
 
-  // No siteMax defined.
-  return false;
+  // Return the value from the root, or false if there is none.
+  return (0 < collectedValues.length) ? collectedValues.pop() : false;
 }
 
 /**

--- a/tidy-propagation.js
+++ b/tidy-propagation.js
@@ -1,12 +1,29 @@
 const cleanClone = require('./lib/cleanClone');
 const getObjectByProperty = require('./lib/getObjectByProperty');
+const { parseAtruleParams } = require('./lib/parseAtruleParams');
+const compareStrings = require('./lib/compareStrings');
 
 function tidyPropagation(declaration, tidy, root) {
   const { atRules, columns: { options: { breakpoints } } } = tidy;
   const rule = declaration.parent;
+  let breakpointKeys = Object.keys(breakpoints);
+
+  // Handle parent atRule.
+  if ('atrule' === rule.parent.type) {
+    const [atRuleParams] = parseAtruleParams(rule.parent.params);
+    const { minMax, value } = atRuleParams;
+
+    // Ignore max-width breakpoints.
+    if ('min' === minMax) {
+      // Rebuild breakpointKeys array without those that won't apply.
+      breakpointKeys = breakpointKeys.filter(breakpoint => (
+        -1 === compareStrings(value, breakpoint)
+      ));
+    }
+  }
 
   // Reverse the breakpoints to make sure they're inserted in the correct order.
-  Object.keys(breakpoints).reverse().forEach((breakpoint) => {
+  breakpointKeys.reverse().forEach((breakpoint) => {
     const atRule = getObjectByProperty(atRules, `(min-width: ${breakpoint})`, 'params');
 
     if (undefined !== atRule) {
@@ -22,12 +39,16 @@ function tidyPropagation(declaration, tidy, root) {
       // Clone the rule and add the cloned declaration.
       const newRule = cleanClone(rule);
       newRule.append(cleanDecl);
-
-      // @todo Need to ensure declarations within atrules are applied as expected
-
       atRule.append(newRule);
 
-      root.insertAfter(rule, atRule);
+      // Insert the media query
+      if ('atrule' === rule.parent.type) {
+        // Insert after the parent at-rule.
+        root.insertAfter(rule.parent, atRule);
+      } else {
+        // Insert after the current rule.
+        root.insertAfter(rule, atRule);
+      }
     }
 
     // Replace the declaration with `!tidy` clipped off.

--- a/tidy-propagation.js
+++ b/tidy-propagation.js
@@ -171,4 +171,5 @@ function tidyPropagation(declaration, tidy) {
 
 module.exports = {
   tidyPropagation,
+  getSiteMax,
 };

--- a/tidy-propagation.js
+++ b/tidy-propagation.js
@@ -27,11 +27,9 @@ function getSiteMax(options) {
 
   // Get any definitions within the breakpoints.
   if (undefined !== breakpoints) {
-    const breakpointKeys = Object.keys(breakpoints);
-
-    const siteMaxValues = breakpointKeys.reduce((acc, breakpoint) => {
-      if (undefined !== breakpoints[breakpoint].siteMax) {
-        return [...acc, breakpoints[breakpoint].siteMax];
+    const siteMaxValues = Object.keys(breakpoints).reduce((acc, bp) => {
+      if (undefined !== breakpoints[bp].siteMax) {
+        return [...acc, breakpoints[bp].siteMax];
       }
 
       return acc;

--- a/tidy-propagation.js
+++ b/tidy-propagation.js
@@ -3,9 +3,10 @@ const getObjectByProperty = require('./lib/getObjectByProperty');
 const { parseAtruleParams } = require('./lib/parseAtruleParams');
 const compareStrings = require('./lib/compareStrings');
 
-function tidyPropagation(declaration, tidy, root) {
+function tidyPropagation(declaration, tidy) {
   const { atRules, columns: { options: { breakpoints } } } = tidy;
   const rule = declaration.parent;
+  const root = declaration.root();
   let breakpointKeys = Object.keys(breakpoints);
 
   // Handle parent atRule.

--- a/tidy-propagation.js
+++ b/tidy-propagation.js
@@ -6,14 +6,14 @@ const compareStrings = require('./lib/compareStrings');
 function tidyPropagation(declaration, tidy) {
   const { columns: { options: { breakpoints } } } = tidy;
   const rule = declaration.parent;
+  const root = declaration.root();
   let breakpointKeys = Object.keys(breakpoints);
 
   // Handle parent atRule.
   const hasAtRuleParent = 'atrule' === rule.parent.type;
-  const [atRuleParams] = hasAtRuleParent
+  const [{ minMax, value }] = hasAtRuleParent
     ? parseAtruleParams(rule.parent.params)
     : [{}];
-  const { minMax, value } = atRuleParams;
 
   // Filter out breakpoint values that don't apply; ignore max-width breakpoints.
   if (hasAtRuleParent && 'min' === minMax) {
@@ -50,14 +50,12 @@ function tidyPropagation(declaration, tidy) {
     return acc;
   }, []);
 
-  const root = declaration.root();
-
   // Insert the media query
   if ('atrule' === rule.parent.type) {
-  //   // Insert after the parent at-rule.
+    // Insert after the parent at-rule.
     root.insertAfter(rule.parent, atRules);
   } else {
-  //   // Insert after the current rule.
+    // Insert after the current rule.
     root.insertAfter(rule, atRules);
   }
 

--- a/tidy-propagation.js
+++ b/tidy-propagation.js
@@ -1,0 +1,48 @@
+const postcss = require('postcss');
+const cleanClone = require('./lib/cleanClone');
+
+function tidyPropagation(declaration, tidy, root) {
+  const { columns: { options: { breakpoints } } } = tidy;
+  const rule = declaration.parent;
+
+  // Reverse the breakpoints to make sure they're inserted in the correct order.
+  Object.keys(breakpoints).reverse().forEach((breakpoint) => {
+    // Clone the declaration without `!tidy`.
+    const cleanDecl = cleanClone(
+      declaration,
+      {
+        declaration: declaration.prop,
+        value: declaration.value.replace(/\s?!tidy/, ''),
+      },
+    );
+
+    // Clone the rule and add the cloned declaration.
+    const newRule = cleanClone(rule);
+    newRule.append(cleanDecl);
+
+    // @todo Need to ensure declarations within atrules are applied as expected
+
+    // Create the atRule and append the rule.
+    const breakpointAtRule = postcss.atRule({
+      name: 'media',
+      params: `(min-width: ${breakpoint})`,
+      nodes: [],
+      source: rule.source,
+    }).append(newRule);
+
+    root.insertAfter(rule, breakpointAtRule);
+  });
+
+  // Replace the declaration with `!tidy` clipped off.
+  declaration.replaceWith(cleanClone(
+    declaration,
+    {
+      declaration: declaration.prop,
+      value: declaration.value.replace(/\s?!tidy/, ''),
+    },
+  ));
+}
+
+module.exports = {
+  tidyPropagation,
+};


### PR DESCRIPTION
Use `!tidy` to denote styles that should be carried over to the breakpoint(s) in the config.

Assuming the following configuration...

```javascript
{
    columns: 12,
    gap: '1.25rem',
    edge: '0.625rem',
    breakpoints: {
      '48rem': {
        gap: '0.625rem',
      },
      '64rem': {
        siteMax: '90rem',
      },
    }
}
```

...the following two blocks are identical

```scss
div {
  tidy-span: 3 !tidy;
}
```
```scss
div {
  tidy-span: 3;

  @media (min-width: 48rem) {
    tidy-span: 3;
  }

  @media (min-width: 64rem) {
    tidy-span: 3;
  }
}
```