### PR TITLE
Adds a test for tidy-var() outputting a CSS Custom Property

### DIFF
--- a/test/tidy-var.test.js
+++ b/test/tidy-var.test.js
@@ -1,6 +1,6 @@
 /* eslint-disable max-len */
 const run = require('.');
-const { typical, typicalWithBreakpoints } = require('./sharedConfigs');
+const { typical, typicalWithBreakpoints, customProperties } = require('./sharedConfigs');
 const { VAR_FUNCTION_REGEX } = require('../tidy-var');
 
 /**
@@ -94,6 +94,15 @@ describe('The `tidy-var()` function is replaced with the expected option value',
       'div { margin-left: -tidy-var("gap"); }',
       'div { margin-left: -1.25rem; }',
       typical,
+    ),
+  );
+
+  test(
+    'Replaces a `tidy-var()` with a Custom Property value',
+    () => run(
+      'div { margin-left: tidy-var(columns); }',
+      'div { margin-left: var(--columns); }',
+      customProperties,
     ),
   );
 });


### PR DESCRIPTION
This works. But using a CSS Custom Property as a tidy-* property value won't. I've added a note to the 0.4.1 Wiki