### PR TITLE
PostCSS 8 API Updates

### DIFF
--- a/.github/workflows/action-test.yml
+++ b/.github/workflows/action-test.yml
@@ -2,9 +2,9 @@ name: Node.js CI
 
 on:
   push:
-    branches: [ master ]
+    branches: [ master, develop ]
   pull_request:
-    branches: [ master ]
+    branches: [ master, develop ]
 
 jobs:
   build:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 **Changed**
 
 - Uses [postcss-calc](https://github.com/postcss/postcss-calc/) to reduce output (#70)
+- Drops support for PostCSS < 8 (#73)
 - Updates dependencies (#72)
 
 ## 0.4.0

--- a/index.js
+++ b/index.js
@@ -1,4 +1,3 @@
-const postcss = require('postcss');
 const Tidy = require('./Tidy');
 const getGlobalOptions = require('./src/getGlobalOptions');
 const { tidyShorthandProperty } = require('./tidy-shorthand-property');
@@ -13,21 +12,32 @@ const { tidyVar } = require('./tidy-var');
  */
 module.exports = (options = {}) => ({
   postcssPlugin: 'postcss-tidy-columns',
-  Once(root) {
-    // Collect the global options.
-    const globalOptions = Object.freeze(getGlobalOptions(root, options));
+  prepare() {
+    let globalOptions = {};
+    let tidy = {};
 
-    // Parse rules and declarations, replace `tidy-` properties.
-    root.walkRules((rule) => {
-      const tidy = new Tidy(rule, globalOptions);
+    return {
+      /**
+       * Collect the global options.
+       */
+      Once(root) {
+        globalOptions = Object.freeze(getGlobalOptions(root, options));
+      },
 
-      // Set up rule-specific properties.
-      tidy.initRule();
+      /**
+       * Set up rule-specific properties.
+       */
+      Rule(rule) {
+        tidy = new Tidy(rule, globalOptions);
 
-      /*
+        // Set up rule-specific properties.
+        tidy.initRule();
+      },
+
+      /**
        * Replace shorthand properties and option value references first
        */
-      rule.walkDecls((declaration) => {
+      Declaration(declaration) {
         // Replace shorthand declarations with their long-form equivalents.
         if (
           declaration.prop.includes('tidy-column')
@@ -40,55 +50,58 @@ module.exports = (options = {}) => ({
         if (declaration.value.includes('tidy-var')) {
           tidyVar(declaration, tidy);
         }
-      });
+      },
 
-      /*
+      /**
        * Replace property and function values with columns expressions.
        */
-      rule.walkDecls((declaration) => {
-        // Replace `tidy-*` properties.
-        if (
-          declaration.prop.includes('tidy-span')
-          || declaration.prop.includes('tidy-offset')
-        ) {
-          tidyProperty(declaration, tidy);
+      RuleExit(rule, { result, atRule }) {
+        rule.walkDecls((declaration) => {
+          // Replace `tidy-*` properties.
+          if (
+            declaration.prop.includes('tidy-span')
+            || declaration.prop.includes('tidy-offset')
+          ) {
+            tidyProperty(declaration, tidy);
+          }
+
+          // Replace `tidy-[span|offset]()` and `tidy-[span|offset]-full()` functions.
+          if (
+            declaration.value.includes('tidy-span')
+            || declaration.value.includes('tidy-offset')
+          ) {
+            tidyFunction(declaration, tidy);
+          }
+        });
+
+        const { fullWidthRule } = tidy;
+        const { siteMax } = tidy.columns.options;
+        const { root } = result;
+
+        // Add the media query if a siteMax is declared and the `fullWidthRule` has children.
+        if (undefined !== siteMax && fullWidthRule.nodes.length > 0) {
+          /**
+           * The siteMax-width atRule.
+           * Contains full-width margin offset declarations.
+           */
+          const fullWidthAtRule = atRule({
+            name: 'media',
+            params: `(min-width: ${siteMax})`,
+            nodes: [],
+            source: rule.source,
+          }).append(fullWidthRule);
+
+          // Insert the media query
+          if ('atrule' === rule.parent.type) {
+            // Insert after the parent at-rule.
+            root.insertAfter(rule.parent, fullWidthAtRule);
+          } else {
+            // Insert after the current rule.
+            root.insertAfter(rule, fullWidthAtRule);
+          }
         }
-
-        // Replace `tidy-[span|offset]()` and `tidy-[span|offset]-full()` functions.
-        if (
-          declaration.value.includes('tidy-span')
-          || declaration.value.includes('tidy-offset')
-        ) {
-          tidyFunction(declaration, tidy);
-        }
-      });
-
-      const { fullWidthRule } = tidy;
-      const { siteMax } = tidy.columns.options;
-
-      // Add the media query if a siteMax is declared and the `fullWidthRule` has children.
-      if (undefined !== siteMax && fullWidthRule.nodes.length > 0) {
-        /**
-         * The siteMax-width atRule.
-         * Contains full-width margin offset declarations.
-         */
-        const fullWidthAtRule = postcss.atRule({
-          name: 'media',
-          params: `(min-width: ${siteMax})`,
-          nodes: [],
-          source: rule.source,
-        }).append(fullWidthRule);
-
-        // Insert the media query
-        if ('atrule' === rule.parent.type) {
-          // Insert after the parent at-rule.
-          root.insertAfter(rule.parent, fullWidthAtRule);
-        } else {
-          // Insert after the current rule.
-          root.insertAfter(rule, fullWidthAtRule);
-        }
-      }
-    });
+      },
+    };
   },
 });
 

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "scripts": {
     "test": "npm run lint && jest",
     "watch": "jest --watchAll",
-    "watch:verbose": "jest --watchAll  --verbose",
+    "watch:verbose": "jest --watchAll  --verbose --detectOpenHandles",
     "build": "npm run build --prefix docs",
     "lint": "eslint *.js src/**/*.js lib/**/*.js test/**/*.js"
   },

--- a/tidy-property.js
+++ b/tidy-property.js
@@ -67,7 +67,7 @@ function tidyProperty(declaration, tidy) {
   }
 
   // Replace`tidy-offset-left|right` declaration with `margin-left|right`.
-  if (OFFSET_REGEX.test(declaration.prop)) {
+  if (declaration.prop.includes('tidy-offset-')) {
     /**
      * {undefined} The full property name.
      * direction:  The side upon which the offset will be applied.

--- a/tidy-var.js
+++ b/tidy-var.js
@@ -22,10 +22,10 @@ function tidyVar(declaration, tidy) {
   const globalRegExp = new RegExp(VAR_FUNCTION_REGEX, 'g');
   const localRegExp = new RegExp(VAR_FUNCTION_REGEX);
 
-  if (localRegExp.test(declaration.value)) {
-    const { columns, columns: { options } } = tidy;
-    const fullMatch = declaration.value.match(globalRegExp);
+  const { columns, columns: { options } } = tidy;
+  const fullMatch = declaration.value.match(globalRegExp);
 
+  if (Array.isArray(fullMatch)) {
     /**
      * Find all matches in the declaration value.
      *


### PR DESCRIPTION
* Uses `prepare()` + Rule and Declaration events ([reference](https://evilmartians.com/chronicles/postcss-8-plugin-migration)]
* Uses quick `String.includes()` checks for property and value tests