### PR TITLE
Cleans up tests and recent changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 - `reduce` option for conditionally reducing the `calc()` output using [postcss-calc](https://github.com/postcss/postcss-calc/) (#70, #79)
 - `base` option for updating the fluid base value's units – `vw` or `%` (#79)
+- Disable an option by setting it to `false` (#80)
 
 **Changed**
 
@@ -19,6 +20,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 **Removed**
 
 - The `breakpoints` option is no longer suppoerted (#79)
+- `tidy-span-full()` and `tidy-offset-full()` are no longer supported (#80)
+- The plugin will no longer create a full-width media query, since it now outputs a single value (#80)
 
 ## 0.4.0
 

--- a/Columns.js
+++ b/Columns.js
@@ -70,7 +70,7 @@ class Columns {
   getSharedGap() {
     const { gap, columns } = this.options;
 
-    // Can't divide a string representing an unknown value..
+    // Can't divide a string representing an unknown value.
     if (isCustomProperty(gap) || isCustomProperty(columns)) {
       return `(${gap} / ${columns} * (${columns} - 1))`;
     }

--- a/Columns.js
+++ b/Columns.js
@@ -15,8 +15,6 @@ class Columns {
   constructor(options = {}) {
     this.options = normalizeOptions(options);
 
-    this.fullWidthRule = null;
-
     // Bind class methods.
     this.init = this.init.bind(this);
     this.getSharedGap = this.getSharedGap.bind(this);

--- a/Tidy.js
+++ b/Tidy.js
@@ -1,6 +1,5 @@
 const Columns = require('./Columns');
 const getLocalOptions = require('./src/getLocalOptions');
-const cleanClone = require('./lib/cleanClone');
 
 /**
  * Tidy class
@@ -12,23 +11,21 @@ const cleanClone = require('./lib/cleanClone');
 class Tidy {
   constructor(rule, globalOptions) {
     this.rule = rule;
+    this.globalOptions = globalOptions;
 
     // Bind class methods.
     this.initRule = this.initRule.bind(this);
-
-    // Merge global and local options.
-    const currentOptions = getLocalOptions(this.rule, globalOptions);
-
-    // Instantiate Columns based on the merged options.
-    this.columns = new Columns(currentOptions);
   }
 
   /**
   * Set up rule-specific properties.
   */
   initRule() {
-    // The media query's selector to which conditional declarations will be appended.
-    this.fullWidthRule = cleanClone(this.rule);
+    // Merge global and local options.
+    const ruleOptions = getLocalOptions(this.rule, this.globalOptions);
+
+    // Instantiate Columns based on the merged options.
+    this.columns = new Columns(ruleOptions);
   }
 
   /**

--- a/index.js
+++ b/index.js
@@ -55,7 +55,7 @@ module.exports = (options = {}) => ({
       /**
        * Replace property and function values with columns expressions.
        */
-      RuleExit(rule, { result, atRule }) {
+      RuleExit(rule) {
         rule.walkDecls((declaration) => {
           // Replace `tidy-*` properties.
           if (
@@ -73,33 +73,6 @@ module.exports = (options = {}) => ({
             tidyFunction(declaration, tidy);
           }
         });
-
-        const { fullWidthRule } = tidy;
-        const { max } = tidy.columns.options;
-        const { root } = result;
-
-        // Add the media query if a max is declared and the `fullWidthRule` has children.
-        if (undefined !== max && fullWidthRule.nodes.length > 0) {
-          /**
-           * The max-width atRule.
-           * Contains full-width margin offset declarations.
-           */
-          const fullWidthAtRule = atRule({
-            name: 'media',
-            params: `(min-width: ${max})`,
-            nodes: [],
-            source: rule.source,
-          }).append(fullWidthRule);
-
-          // Insert the media query
-          if ('atrule' === rule.parent.type) {
-            // Insert after the parent at-rule.
-            root.insertAfter(rule.parent, fullWidthAtRule);
-          } else {
-            // Insert after the current rule.
-            root.insertAfter(rule, fullWidthAtRule);
-          }
-        }
       },
     };
   },

--- a/index.js
+++ b/index.js
@@ -65,7 +65,7 @@ module.exports = (options = {}) => ({
             tidyProperty(declaration, tidy);
           }
 
-          // Replace `tidy-[span|offset]()` and `tidy-[span|offset]-full()` functions.
+          // Replace `tidy-[span|offset]()` functions.
           if (
             declaration.value.includes('tidy-span')
             || declaration.value.includes('tidy-offset')

--- a/lib/cleanClone.js
+++ b/lib/cleanClone.js
@@ -9,7 +9,7 @@
 function cleanClone(node, overrides = {}) {
   const cleaner = (node.nodes) ? { nodes: [] } : {};
   // Clone the node with overrides.
-  const clonedNode = node.clone(Object.assign(overrides, cleaner));
+  const clonedNode = node.clone({ ...overrides, ...cleaner });
   // Clear raw formatting, which will be inherited upon insertion.
   clonedNode.cleanRaws();
 

--- a/lib/detectCalcWrapper.js
+++ b/lib/detectCalcWrapper.js
@@ -13,7 +13,7 @@
  * ]
  */
 function detectCalcWrapper(declaration) {
-  const FUNCTION_REGEX = /tidy-(span|offset)(-full)?\(([\d.-]+)\)/g;
+  const FUNCTION_REGEX = /tidy-(span|offset)\(([\d.-]+)\)/g;
 
   if (/calc/.test(declaration)) {
     // Split the declaration at the calc function(s).
@@ -21,7 +21,7 @@ function detectCalcWrapper(declaration) {
 
     const calcResults = calcSplit
       // Ensure there is a calc() function within the string.
-      .filter(split => split.match(FUNCTION_REGEX) && '' !== split)
+      .filter((split) => split.match(FUNCTION_REGEX) && '' !== split)
       // Extract the string within balanced parentheses.
       .reduce((acc, piece) => {
         let balanced = false;
@@ -78,8 +78,8 @@ function detectCalcWrapper(declaration) {
   const matches = declaration.match(FUNCTION_REGEX) || [];
   return matches
     // Filter out any falsy values.
-    .filter(match => match)
-    .map(match => ({ match, isNested: false }));
+    .filter((match) => match)
+    .map((match) => ({ match, isNested: false }));
 }
 
 module.exports = detectCalcWrapper;

--- a/lib/hasEmptyValue.js
+++ b/lib/hasEmptyValue.js
@@ -2,8 +2,17 @@
  * Returns true for values that contain an empty or otherwise useless value.
  *
  * @param  {Mixed} values The value to be checked.
- * @return {Boolean}        Whether the value is considered empty.
+ * @return {Boolean}      Whether the value is considered empty.
  */
-const hasEmptyValue = value => [null, undefined, 0, '0'].includes(value);
+const hasEmptyValue = (value) => (
+  [
+    false,
+    'false',
+    null,
+    undefined,
+    0,
+    '0',
+  ].includes(value)
+);
 
 module.exports = hasEmptyValue;

--- a/lib/test/detectCalcWrapper.test.js
+++ b/lib/test/detectCalcWrapper.test.js
@@ -11,8 +11,8 @@ describe('Extract tidy-span|offset functions and note whether it is nested withi
       [{ match: 'tidy-span(3)', isNested: true }],
     ],
     [
-      'calc((20px + 100) + tidy-offset-full(3) + (60px - 1))',
-      [{ match: 'tidy-offset-full(3)', isNested: true }],
+      'calc((20px + 100) + tidy-offset(3) + (60px - 1))',
+      [{ match: 'tidy-offset(3)', isNested: true }],
     ],
     [
       'calc(20px + tidy-span(3))',
@@ -23,8 +23,8 @@ describe('Extract tidy-span|offset functions and note whether it is nested withi
       [{ match: 'tidy-offset(3)', isNested: true }],
     ],
     [
-      'calc(20px + tidy-span-full(3) + (60px - 1))',
-      [{ match: 'tidy-span-full(3)', isNested: true }],
+      'calc(20px + tidy-span(3) + (60px - 1))',
+      [{ match: 'tidy-span(3)', isNested: true }],
     ],
     [
       'calc((20px + 100) + tidy-span(3) + 60px)',
@@ -35,61 +35,61 @@ describe('Extract tidy-span|offset functions and note whether it is nested withi
       [{ match: 'tidy-span(3)', isNested: true }],
     ],
     [
-      'calc(tidy-offset-full(3) + (20px * 6))',
-      [{ match: 'tidy-offset-full(3)', isNested: true }],
+      'calc(tidy-offset(3) + (20px * 6))',
+      [{ match: 'tidy-offset(3)', isNested: true }],
     ],
     [
       '0 calc((20px + (100)) + (tidy-offset(3) + (60px - 1))) 0 calc(400 + 3)',
       [{ match: 'tidy-offset(3)', isNested: true }],
     ],
     [
-      '0 calc(((((20px + 100) / 14) * 3) + tidy-offset-full(3)) + (60px - 1)) 0 calc(tidy-offset(6) + 3px)',
+      '0 calc(((((20px + 100) / 14) * 3) + tidy-offset(3)) + (60px - 1)) 0 calc(tidy-offset(6) + 3px)',
       [
-        { match: 'tidy-offset-full(3)', isNested: true },
+        { match: 'tidy-offset(3)', isNested: true },
         { match: 'tidy-offset(6)', isNested: true },
       ],
     ],
     [
-      '0 calc((20px + 100) + tidy-span-full(3) + (60px - 1)) 0 calc(tidy-offset-full(5) + (3px * 2))',
+      '0 calc((20px + 100) + tidy-span(3) + (60px - 1)) 0 calc(tidy-offset(5) + (3px * 2))',
       [
-        { match: 'tidy-span-full(3)', isNested: true },
-        { match: 'tidy-offset-full(5)', isNested: true },
+        { match: 'tidy-span(3)', isNested: true },
+        { match: 'tidy-offset(5)', isNested: true },
       ],
     ],
     [
-      '0 calc((20px + 100) + tidy-offset-full(3) + (60px - 1)) 0 calc(100px + tidy-span-full(4) + (3px * 2))',
+      '0 calc((20px + 100) + tidy-offset(3) + (60px - 1)) 0 calc(100px + tidy-span(4) + (3px * 2))',
       [
-        { match: 'tidy-offset-full(3)', isNested: true },
-        { match: 'tidy-span-full(4)', isNested: true },
+        { match: 'tidy-offset(3)', isNested: true },
+        { match: 'tidy-span(4)', isNested: true },
       ],
     ],
     [
-      '0 tidy-offset-full(3) 0 calc(100px + tidy-span-full(4) + (3px * 2))',
+      '0 tidy-offset(3) 0 calc(100px + tidy-span(4) + (3px * 2))',
       [
-        { match: 'tidy-offset-full(3)', isNested: false },
-        { match: 'tidy-span-full(4)', isNested: true },
+        { match: 'tidy-offset(3)', isNested: false },
+        { match: 'tidy-span(4)', isNested: true },
       ],
     ],
     [
       // No calc() function.
-      '0 tidy-span(3) 0 tidy-offset-full(9)',
+      '0 tidy-span(3) 0 tidy-offset(9)',
       [
         {
           match: 'tidy-span(3)',
           isNested: false,
         },
         {
-          match: 'tidy-offset-full(9)',
+          match: 'tidy-offset(9)',
           isNested: false,
         },
       ],
     ],
     [
       // No calc() function.
-      '0 calc(100% - 20px) 0 tidy-offset-full(9)',
+      '0 calc(100% - 20px) 0 tidy-offset(9)',
       [
         {
-          match: 'tidy-offset-full(9)',
+          match: 'tidy-offset(9)',
           isNested: false,
         },
       ],

--- a/src/getLocalOptions.js
+++ b/src/getLocalOptions.js
@@ -16,7 +16,7 @@ function getLocalOptions(rule, global) {
   // Parse the rule's CSS option values.
   const atRuleOpts = parseOptions(atRuleParams);
 
-  return Object.assign({}, global, atRuleOpts);
+  return { ...global, ...atRuleOpts };
 }
 
 module.exports = getLocalOptions;

--- a/src/normalizeOptions.js
+++ b/src/normalizeOptions.js
@@ -20,6 +20,12 @@ function normalizeOptions(options) {
     .reduce((acc, key) => {
       const option = options[key];
 
+      // Short circuit if the value is false.
+      if ('false' === String(option)) {
+        acc[key] = undefined;
+        return acc;
+      }
+
       if (isCustomProperty(option)) {
         // Use the raw option value if it's a var() function.
         acc[key] = option;
@@ -35,8 +41,8 @@ function normalizeOptions(options) {
         }
 
         // `debug` and `reduce` should be a Boolean value.
-        if (['debug', 'reduce'].includes(key) && ['true', 'false'].includes(String(option))) {
-          acc[key] = ('true' === String(option));
+        if (['debug', 'reduce'].includes(key) && 'true' === String(option)) {
+          acc[key] = true;
         }
 
         // These should all be valid, positive CSS length values.

--- a/src/test/getLocalOptions.test.js
+++ b/src/test/getLocalOptions.test.js
@@ -47,4 +47,18 @@ describe('Walk any `tidy` at-rules and collect locally-scoped options.', () => {
       columnsOnly,
     ),
   );
+
+  test(
+    '@tidy value set to false removes the global option',
+    () => runLocalOptionsPlugin(
+      'div { @tidy edge false; @tidy gap false; }',
+      {
+        columns: 12,
+        edge: undefined,
+        gap: undefined,
+        max: '90rem',
+      },
+      typical,
+    ),
+  );
 });

--- a/test/Columns.test.js
+++ b/test/Columns.test.js
@@ -185,6 +185,11 @@ describe('Get calc functions from spanCalc()', () => {
     const pixel = new Columns({ ...columnsOnly, base: 'px' });
     expect(pixel.spanCalc(1)).toBe('calc(100vw / 12)');
   });
+
+  test('`reduce` option changes output', () => {
+    expect(new Columns({ ...allValues, reduce: true }).spanCalc(2))
+      .not.toBe('calc((((min(100vw, 75rem) - 32px * 2) / 16 - 0.5859rem) * 2) + 0.625rem)');
+  });
 });
 
 describe('Get calc functions from offsetCalc()', () => {

--- a/test/Columns.test.js
+++ b/test/Columns.test.js
@@ -13,50 +13,44 @@ const {
 const Columns = require('../Columns');
 
 /**
- * Test a method of the Columns class.
- *
- * @param {Object} testConfig {
- *   @param {String} testConfig.description The test suite description.
- *   @param {Array}  testConfig.tests       An array of Test Objects
- * }
+ * Calculate the shared gap amount to be removed from each column.
  */
-const testColumnsMethod = (testConfig) => {
-  describe(testConfig.description, () => {
-    /**
-     * Run each test.
-     *
-     * @param {Object} unitTest {
-     *   @param {String} unitTest.description The test description.
-     *   @param {String} unitTest.actual      The test's plugin output.
-     *   @param {String} unitTest.expected    The expected plugin output.
-     * }
-     */
-    const reducedTests = testConfig.tests.reduce((acc, test) => {
-      if (true === test.skip) {
-        return acc;
-      }
-
-      return [...acc, Object.values(test)];
-    }, []);
-
-    test.each(reducedTests)(
-      '%s',
-      (theTest, actual, expected) => {
-        expect(actual).toEqual(expected);
-      },
-    );
-  });
-};
+test('Calculate the shared gap amount to be removed from each column', () => {
+  // Calculates a shared gap with `rem` value.
+  expect(new Columns(allValues).getSharedGap())
+    .toBe('0.5859rem');
+  // Calculates a shared gap with `px` value.
+  expect(new Columns(edgeGap).getSharedGap())
+    .toBe('9.1667px');
+  // Calculates a `0` shared gap if a gap option is not declared.
+  expect(new Columns(edgeMax).getSharedGap())
+    .toBe(0);
+  // Builds the shared gap calculation when `gap` is a CSS Custom Property.
+  expect(new Columns(customProperties).getSharedGap())
+    .toBe(`(${customProperties.gap} / ${customProperties.columns} * (${customProperties.columns} - 1))`);
+});
 
 describe('Checking values passed to Columns.buildCalcFunction()', () => {
-  describe('All options', () => {
-    const instance = new Columns(allValues);
-    jest.spyOn(instance, 'buildCalcFunction');
+  const instance = new Columns(allValues);
+  jest.spyOn(instance, 'buildCalcFunction');
+
+  describe('From spanCalc', () => {
+    test('Fractional columns (lower than 1)', () => {
+      instance.spanCalc(0.5);
+      expect(instance.buildCalcFunction).toHaveBeenCalledWith(0.5, -0); // @todo These should be 0.
+      expect(instance.buildCalcFunction).toHaveBeenCalledWith(0.5, -0); // @todo These should be 0.
+    });
 
     test('Single column', () => {
       instance.spanCalc(1);
       expect(instance.buildCalcFunction).toHaveBeenCalledWith(1, 0);
       expect(instance.buildCalcFunction).toHaveBeenCalledWith(1, 0);
+    });
+
+    test('Fractional columns (greater than 1)', () => {
+      instance.spanCalc(1.75);
+      expect(instance.buildCalcFunction).toHaveBeenCalledWith(1.75, 1);
+      expect(instance.buildCalcFunction).toHaveBeenCalledWith(1.75, 1);
     });
 
     test('Fractional columns (greater than 2)', () => {
@@ -66,290 +60,180 @@ describe('Checking values passed to Columns.buildCalcFunction()', () => {
     });
   });
 
-  test('Omits a `full` value with no `max` option', () => {
-    const instance = new Columns(edgeGap);
-    jest.spyOn(instance, 'buildCalcFunction');
-
-    instance.spanCalc(2.5);
-    expect(instance.buildCalcFunction).toHaveBeenCalledWith(2.5, 2);
-  });
-});
-
-describe('Get calc functions from buildCalcFunction()', () => {
-  describe('All options', () => {
-    const instance = new Columns(allValues); // eslint-disable-line
+  describe('From offsetCalc', () => {
+    test('Fractional columns (lower than 1)', () => {
+      instance.offsetCalc(0.5);
+      expect(instance.buildCalcFunction).toHaveBeenCalledWith(0.5, 0);
+      expect(instance.buildCalcFunction).toHaveBeenCalledWith(0.5, 0);
+    });
 
     test('Single column', () => {
-      const expected = 'calc((min(100vw, 75rem) - 32px * 2) / 16 - 0.5859rem)';
+      instance.offsetCalc(1);
+      expect(instance.buildCalcFunction).toHaveBeenCalledWith(1, 1);
+      expect(instance.buildCalcFunction).toHaveBeenCalledWith(1, 1);
+    });
 
-      expect(instance.buildCalcFunction(1, 0)).toEqual(expected);
+    test('Fractional columns (greater than 1)', () => {
+      instance.offsetCalc(1.75);
+      expect(instance.buildCalcFunction).toHaveBeenCalledWith(1.75, 1);
+      expect(instance.buildCalcFunction).toHaveBeenCalledWith(1.75, 1);
     });
 
     test('Fractional columns (greater than 2)', () => {
-      const expected = 'calc((((min(100vw, 75rem) - 32px * 2) / 16 - 0.5859rem) * 2.5) + 0.625rem * 2)';
-
-      expect(instance.buildCalcFunction(2.5, 2)).toEqual(expected);
+      instance.offsetCalc(2.5);
+      expect(instance.buildCalcFunction).toHaveBeenCalledWith(2.5, 2);
+      expect(instance.buildCalcFunction).toHaveBeenCalledWith(2.5, 2);
     });
   });
+});
 
-  test('Uses 100% as the fluid base', () => {
-    const instance = new Columns({ ...columnsOnly, base: '%' });
+describe('Get calc functions from spanCalc()', () => {
+  test('All options', () => {
+    const instance = new Columns(allValues);
 
-    const expected = 'calc(100% / 12)';
+    // Single column.
+    expect(instance.spanCalc(1))
+      .toBe('calc((min(100vw, 75rem) - 32px * 2) / 16 - 0.5859rem)');
 
-    expect(instance.buildCalcFunction(1, 0)).toEqual(expected);
+    // Two columns (one gap).
+    expect(instance.spanCalc(2))
+      .toBe('calc((((min(100vw, 75rem) - 32px * 2) / 16 - 0.5859rem) * 2) + 0.625rem)');
+
+    // Multiple columns.
+    expect(instance.spanCalc(4))
+      .toBe('calc((((min(100vw, 75rem) - 32px * 2) / 16 - 0.5859rem) * 4) + 0.625rem * 3)');
+
+    // Fractional columns (less than 1)
+    expect(instance.spanCalc(0.5))
+      .toBe('calc(((min(100vw, 75rem) - 32px * 2) / 16 - 0.5859rem) * 0.5)');
+
+    // Fractional columns (greater than 1)
+    expect(instance.spanCalc(1.75))
+      .toBe('calc((((min(100vw, 75rem) - 32px * 2) / 16 - 0.5859rem) * 1.75) + 0.625rem)');
+
+    // Fractional columns (greater than 2)
+    expect(instance.spanCalc(2.5))
+      .toBe('calc((((min(100vw, 75rem) - 32px * 2) / 16 - 0.5859rem) * 2.5) + 0.625rem * 2)');
   });
 
-  test('Ignores invalid base option value', () => {
-    const instance = new Columns({ ...columnsOnly, base: 'px' });
+  test('Various missing option values', () => {
+    // 'Omits a `full` value with no `max` option',
+    expect(new Columns(edgeGap).spanCalc(1))
+      .toBe('calc((100vw - 1rem * 2) / 12 - 9.1667px)');
 
-    const expected = 'calc(100vw / 12)';
+    // 'Omits shared gap for single column with no `gap` option',
+    expect(new Columns(edgeMax).spanCalc(1))
+      .toBe('calc((min(100vw, 1024px) - 1.25rem * 2) / 16)');
 
-    expect(instance.buildCalcFunction(1, 0)).toEqual(expected);
+    // 'Omits the gap addition wtih no `gap` option',
+    expect(new Columns(edgeMax).spanCalc(2))
+      .toBe('calc(((min(100vw, 1024px) - 1.25rem * 2) / 16) * 2)');
+
+    // 'Omits the edge subtraction with no `edge` option',
+    expect(new Columns(gapMax).spanCalc(1))
+      .toBe('calc(min(100vw, 60rem) / 16 - 14.0625px)');
+
+    // 'Omits undeclared values from span ouput: `edge` only',
+    expect(new Columns(edgeOnly).spanCalc(1))
+      .toBe('calc((100vw - 20px * 2) / 12)');
+
+    // 'Omits undeclared values from span ouput: `gap` only',
+    expect(new Columns(gapOnly).spanCalc(1))
+      .toBe('calc(100vw / 12 - 0.8594rem)');
+
+    // 'Omits undeclared values from span ouput: `max` only',
+    expect(new Columns(maxOnly).spanCalc(1))
+      .toBe('calc(min(100vw, var(--tmax)) / 16)');
+
+    // 'Omits undeclared values from span ouput: `edge` only (multiple columns)',
+    expect(new Columns(maxOnly).spanCalc(5))
+      .toBe('calc((min(100vw, var(--tmax)) / 16) * 5)');
+
+    // 'Omits undeclared values from span ouput: `columns` only',
+    expect(new Columns(columnsOnly).spanCalc(1))
+      .toBe('calc(100vw / 12)');
+
+    // 'Omits undeclared values from span ouput: `columns` only (multiple columns)',
+    expect(new Columns(columnsOnly).spanCalc(3))
+      .toBe('calc((100vw / 12) * 3)');
+
+    // Custom properties used in option values.
+    expect(new Columns(customProperties).spanCalc(3))
+      .toBe('calc((((min(100vw, 90rem) - var(--edge) * 2) / var(--columns) - (var(--gap) / var(--columns) * (var(--columns) - 1))) * 3) + var(--gap) * 2)');
+  });
+
+  test('`base` option applied as expected', () => {
+    const percent = new Columns({ ...columnsOnly, base: '%' });
+    expect(percent.spanCalc(1)).toBe('calc(100% / 12)');
+
+    const pixel = new Columns({ ...columnsOnly, base: 'px' });
+    expect(pixel.spanCalc(1)).toBe('calc(100vw / 12)');
   });
 });
 
-/**
- * Calculate the shared gap amount to be removed from each column.
- */
-testColumnsMethod({
-  description: 'Calculate the shared gap amount to be removed from each column',
-  tests: [
-    {
-      description: 'Calculates a shared gap with `rem` value',
-      actual: new Columns(allValues).getSharedGap(),
-      expected: '0.5859rem',
-    },
-    {
-      description: 'Calculates a shared gap with `px` value',
-      actual: new Columns(edgeGap).getSharedGap(),
-      expected: '9.1667px',
-    },
-    {
-      description: 'Calculates a `0` shared gap if a gap option is not declared',
-      actual: new Columns(edgeMax).getSharedGap(),
-      expected: 0,
-    },
-    {
-      description: 'Builds the shared gap calculation when `gap` is a CSS Custom Property',
-      actual: new Columns(customProperties).getSharedGap(),
-      expected: `(${customProperties.gap} / ${customProperties.columns} * (${customProperties.columns} - 1))`,
-    },
-  ],
-});
+describe('Get calc functions from offsetCalc()', () => {
+  test('All options', () => {
+    const instance = new Columns(allValues);
 
-/**
- * Create the column `calc()` function declaration for each base value.
- */
-testColumnsMethod({
-  description: 'Create the column `calc()` function declaration for each base value',
-  tests: [
-    // ---------- All options
-    {
-      description: 'All options: single column',
-      actual: new Columns(allValues).spanCalc(1),
-      expected: 'calc((min(100vw, 75rem) - 32px * 2) / 16 - 0.5859rem)',
-    },
-    {
-      description: 'All options: two columns',
-      actual: new Columns(allValues).spanCalc(2),
-      expected: 'calc((((min(100vw, 75rem) - 32px * 2) / 16 - 0.5859rem) * 2) + 0.625rem)',
-    },
-    {
-      description: 'All options: three columns',
-      actual: new Columns(allValues).spanCalc(4),
-      expected: 'calc((((min(100vw, 75rem) - 32px * 2) / 16 - 0.5859rem) * 4) + 0.625rem * 3)',
-    },
-    {
-      description: 'All options: negative columns',
-      actual: new Columns(allValues).spanCalc(-4),
-      expected: 'calc((((min(100vw, 75rem) - 32px * 2) / 16 - 0.5859rem) * -4) + 0.625rem * -3)',
-    },
-    {
-      description: 'All options: fractional columns (less than 1)',
-      actual: new Columns(allValues).spanCalc(0.5),
-      expected: 'calc(((min(100vw, 75rem) - 32px * 2) / 16 - 0.5859rem) * 0.5)',
-    },
-    {
-      description: 'All options: fractional columns (greater than 1)',
-      actual: new Columns(allValues).spanCalc(1.75),
-      expected: 'calc((((min(100vw, 75rem) - 32px * 2) / 16 - 0.5859rem) * 1.75) + 0.625rem)',
-    },
-    {
-      description: 'All options: fractional columns (greater than 2)',
-      actual: new Columns(allValues).spanCalc(2.5),
-      expected: 'calc((((min(100vw, 75rem) - 32px * 2) / 16 - 0.5859rem) * 2.5) + 0.625rem * 2)',
-    },
-    // ---------- No max
-    {
-      description: 'Omits a `full` value with no `max` option',
-      actual: new Columns(edgeGap).spanCalc(1),
-      expected: 'calc((100vw - 1rem * 2) / 12 - 9.1667px)',
-    },
-    // ---------- No gap
-    {
-      description: 'Omits shared gap for single column with no `gap` option',
-      actual: new Columns(edgeMax).spanCalc(1),
-      expected: 'calc((min(100vw, 1024px) - 1.25rem * 2) / 16)',
-    },
-    {
-      description: 'Omits the gap addition wtih no `gap` option',
-      actual: new Columns(edgeMax).spanCalc(2),
-      expected: 'calc(((min(100vw, 1024px) - 1.25rem * 2) / 16) * 2)',
-    },
-    // ---------- No edge
-    {
-      description: 'Omits the edge subtraction with no `edge` option',
-      actual: new Columns(gapMax).spanCalc(1),
-      expected: 'calc(min(100vw, 60rem) / 16 - 14.0625px)',
-    },
-    // ---------- Edges only
-    {
-      description: 'Omits undeclared values from span ouput: `edge` only',
-      actual: new Columns(edgeOnly).spanCalc(1),
-      expected: 'calc((100vw - 20px * 2) / 12)',
-    },
-    // ---------- Gap only
-    {
-      description: 'Omits undeclared values from span ouput: `gap` only',
-      actual: new Columns(gapOnly).spanCalc(1),
-      expected: 'calc(100vw / 12 - 0.8594rem)',
-    },
-    // ---------- max only
-    {
-      description: 'Omits undeclared values from span ouput: `max` only',
-      actual: new Columns(maxOnly).spanCalc(1),
-      expected: 'calc(min(100vw, var(--tmax)) / 16)',
-    },
-    {
-      description: 'Omits undeclared values from span ouput: `edge` only (multiple columns)',
-      actual: new Columns(maxOnly).spanCalc(5),
-      expected: 'calc((min(100vw, var(--tmax)) / 16) * 5)',
-    },
-    // ---------- Columns only
-    {
-      description: 'Omits undeclared values from span ouput: `columns` only',
-      actual: new Columns(columnsOnly).spanCalc(1),
-      expected: 'calc(100vw / 12)',
-    },
-    {
-      description: 'Omits undeclared values from span ouput: `columns` only (multiple columns)',
-      actual: new Columns(columnsOnly).spanCalc(3),
-      expected: 'calc((100vw / 12) * 3)',
-    },
-    // ---------- Custom Properties
-    {
-      description: 'Custom properties used in option values',
-      actual: new Columns(customProperties).spanCalc(3),
-      expected: 'calc((((min(100vw, 90rem) - var(--edge) * 2) / var(--columns) - (var(--gap) / var(--columns) * (var(--columns) - 1))) * 3) + var(--gap) * 2)',
-    },
-  ],
-});
+    // Single column.
+    expect(instance.offsetCalc(1))
+      .toBe('calc(((min(100vw, 75rem) - 32px * 2) / 16 - 0.5859rem) + 0.625rem)');
 
-/**
- * Create the offset `calc()` function declaration for each base value.
- */
-testColumnsMethod({
-  description: 'Create the offset `calc()` function declaration for each base value',
-  tests: [
-    // ---------- All options
-    {
-      description: 'All options: single column',
-      actual: new Columns(allValues).offsetCalc(1),
-      expected: 'calc(((min(100vw, 75rem) - 32px * 2) / 16 - 0.5859rem) + 0.625rem)',
-    },
-    {
-      description: 'All options: two columns',
-      actual: new Columns(allValues).offsetCalc(2),
-      expected: 'calc((((min(100vw, 75rem) - 32px * 2) / 16 - 0.5859rem) * 2) + 0.625rem * 2)',
-    },
-    {
-      description: 'All options: three columns',
-      actual: new Columns(allValues).offsetCalc(3),
-      expected: 'calc((((min(100vw, 75rem) - 32px * 2) / 16 - 0.5859rem) * 3) + 0.625rem * 3)',
-    },
-    {
-      description: 'All options: negative columns',
-      actual: new Columns(allValues).offsetCalc(-4),
-      expected: 'calc((((min(100vw, 75rem) - 32px * 2) / 16 - 0.5859rem) * -4) + 0.625rem * -4)',
-    },
-    {
-      description: 'All options: fractional columns (less than 1)',
-      actual: new Columns(allValues).offsetCalc(0.75),
-      expected: 'calc(((min(100vw, 75rem) - 32px * 2) / 16 - 0.5859rem) * 0.75)',
-    },
-    {
-      description: 'All options: fractional columns (greater than 1)',
-      actual: new Columns(allValues).offsetCalc(1.5),
-      expected: 'calc((((min(100vw, 75rem) - 32px * 2) / 16 - 0.5859rem) * 1.5) + 0.625rem)',
-    },
-    {
-      description: 'All options: fractional columns (greater than 2)',
-      actual: new Columns(allValues).offsetCalc(2.075),
-      expected: 'calc((((min(100vw, 75rem) - 32px * 2) / 16 - 0.5859rem) * 2.075) + 0.625rem * 2)',
-    },
-    // ---------- No max
-    {
-      description: 'Omits a `full` value with no `max` option',
-      actual: new Columns(edgeGap).offsetCalc(1),
-      expected: 'calc(((100vw - 1rem * 2) / 12 - 9.1667px) + 10px)',
-    },
-    // ---------- No gap
-    {
-      description: 'Omits shared gap for single column with no `gap` option',
-      actual: new Columns(edgeMax).offsetCalc(1),
-      expected: 'calc((min(100vw, 1024px) - 1.25rem * 2) / 16)',
-    },
-    {
-      description: 'Omits the gap addition wtih no `gap` option',
-      actual: new Columns(edgeMax).offsetCalc(2),
-      expected: 'calc(((min(100vw, 1024px) - 1.25rem * 2) / 16) * 2)',
-    },
-    // ---------- No edge
-    {
-      description: 'Omits the edge subtraction with no `edge` option',
-      actual: new Columns(gapMax).offsetCalc(1),
-      expected: 'calc((min(100vw, 60rem) / 16 - 14.0625px) + 15px)',
-    },
-    // ---------- Edges only
-    {
-      description: 'Omits undeclared values from span ouput: `edge` only',
-      actual: new Columns(edgeOnly).offsetCalc(1),
-      expected: 'calc((100vw - 20px * 2) / 12)',
-    },
-    {
-      description: 'Omits undeclared values from span ouput: `edge` only (multiple columns)',
-      actual: new Columns(edgeOnly).offsetCalc(2),
-      expected: 'calc(((100vw - 20px * 2) / 12) * 2)',
-    },
-    // ---------- Gap only
-    {
-      description: 'Omits undeclared values from span ouput: `gap` only',
-      actual: new Columns(gapOnly).offsetCalc(1),
-      expected: 'calc((100vw / 12 - 0.8594rem) + 0.9375rem)',
-    },
-    // ---------- max only
-    {
-      description: 'Omits undeclared values from span ouput: `max` only',
-      actual: new Columns(maxOnly).offsetCalc(1),
-      expected: 'calc(min(100vw, var(--tmax)) / 16)',
-    },
-    // ---------- Columns only
-    {
-      description: 'Omits undeclared values from span ouput: `columns` only',
-      actual: new Columns(columnsOnly).offsetCalc(1),
-      expected: 'calc(100vw / 12)',
-    },
-    {
-      description: 'Omits undeclared values from span ouput: `columns` only (multiple columns)',
-      actual: new Columns(columnsOnly).offsetCalc(4),
-      expected: 'calc((100vw / 12) * 4)',
-    },
-    // ---------- Custom Properties
-    {
-      description: 'Custom properties used in option values',
-      actual: new Columns(customProperties).offsetCalc(3),
-      expected: 'calc((((min(100vw, 90rem) - var(--edge) * 2) / var(--columns) - (var(--gap) / var(--columns) * (var(--columns) - 1))) * 3) + var(--gap) * 3)',
-    },
-  ],
+    // Two columns (two gaps).
+    expect(instance.offsetCalc(2))
+      .toBe('calc((((min(100vw, 75rem) - 32px * 2) / 16 - 0.5859rem) * 2) + 0.625rem * 2)');
+
+    // Multiple columns.
+    expect(instance.offsetCalc(4))
+      .toBe('calc((((min(100vw, 75rem) - 32px * 2) / 16 - 0.5859rem) * 4) + 0.625rem * 4)');
+
+    // Fractional columns (less than 1).
+    expect(instance.offsetCalc(0.75))
+      .toBe('calc(((min(100vw, 75rem) - 32px * 2) / 16 - 0.5859rem) * 0.75)');
+
+    // Fractional columns (greater than 1).
+    expect(instance.offsetCalc(1.5))
+      .toBe('calc((((min(100vw, 75rem) - 32px * 2) / 16 - 0.5859rem) * 1.5) + 0.625rem)');
+
+    // Fractional columns (greater than 2).
+    expect(instance.offsetCalc(2.075))
+      .toBe('calc((((min(100vw, 75rem) - 32px * 2) / 16 - 0.5859rem) * 2.075) + 0.625rem * 2)');
+  });
+
+  test('Various missing option values', () => {
+    // Omits a `full` value with no `max` option
+    expect(new Columns(edgeGap).offsetCalc(1))
+      .toBe('calc(((100vw - 1rem * 2) / 12 - 9.1667px) + 10px)');
+    // Omits shared gap for single column with no `gap` option
+    expect(new Columns(edgeMax).offsetCalc(1))
+      .toBe('calc((min(100vw, 1024px) - 1.25rem * 2) / 16)');
+    // Omits the gap addition wtih no `gap` option
+    expect(new Columns(edgeMax).offsetCalc(2))
+      .toBe('calc(((min(100vw, 1024px) - 1.25rem * 2) / 16) * 2)');
+    // Omits the edge subtraction with no `edge` option
+    expect(new Columns(gapMax).offsetCalc(1))
+      .toBe('calc((min(100vw, 60rem) / 16 - 14.0625px) + 15px)');
+    // Omits undeclared values from span ouput: `edge` only
+    expect(new Columns(edgeOnly).offsetCalc(1))
+      .toBe('calc((100vw - 20px * 2) / 12)');
+    // Omits undeclared values from span ouput: `edge` only (multiple columns)
+    expect(new Columns(edgeOnly).offsetCalc(2))
+      .toBe('calc(((100vw - 20px * 2) / 12) * 2)');
+    // Omits undeclared values from span ouput: `gap` only
+    expect(new Columns(gapOnly).offsetCalc(1))
+      .toBe('calc((100vw / 12 - 0.8594rem) + 0.9375rem)');
+    // Omits undeclared values from span ouput: `max` only
+    expect(new Columns(maxOnly).offsetCalc(1))
+      .toBe('calc(min(100vw, var(--tmax)) / 16)');
+    // Omits undeclared values from span ouput: `columns` only
+    expect(new Columns(columnsOnly).offsetCalc(1))
+      .toBe('calc(100vw / 12)');
+    // Omits undeclared values from span ouput: `columns` only (multiple columns)
+    expect(new Columns(columnsOnly).offsetCalc(4))
+      .toBe('calc((100vw / 12) * 4)');
+
+    // Custom properties used in option values.
+    expect(new Columns(customProperties).offsetCalc(3))
+      .toBe('calc((((min(100vw, 90rem) - var(--edge) * 2) / var(--columns) - (var(--gap) / var(--columns) * (var(--columns) - 1))) * 3) + var(--gap) * 3)');
+  });
 });

--- a/test/Columns.test.js
+++ b/test/Columns.test.js
@@ -37,8 +37,8 @@ describe('Checking values passed to Columns.buildCalcFunction()', () => {
   describe('From spanCalc', () => {
     test('Fractional columns (lower than 1)', () => {
       instance.spanCalc(0.5);
-      expect(instance.buildCalcFunction).toHaveBeenCalledWith(0.5, -0); // @todo These should be 0.
-      expect(instance.buildCalcFunction).toHaveBeenCalledWith(0.5, -0); // @todo These should be 0.
+      expect(instance.buildCalcFunction).toHaveBeenCalledWith(0.5, -0);
+      expect(instance.buildCalcFunction).toHaveBeenCalledWith(0.5, -0);
     });
 
     test('Single column', () => {
@@ -160,6 +160,22 @@ describe('Get calc functions from spanCalc()', () => {
     // Custom properties used in option values.
     expect(new Columns(customProperties).spanCalc(3))
       .toBe('calc((((min(100vw, 90rem) - var(--edge) * 2) / var(--columns) - (var(--gap) / var(--columns) * (var(--columns) - 1))) * 3) + var(--gap) * 2)');
+
+    // var() function for `max` value.
+    expect(new Columns({ ...allValues, max: 'var(--tmax)' }).spanCalc(3))
+      .toBe('calc((((min(100vw, var(--tmax)) - 32px * 2) / 16 - 0.5859rem) * 3) + 0.625rem * 2)');
+
+    // var() function for `edge` value.
+    expect(new Columns({ ...allValues, edge: 'var(--tedge)' }).spanCalc(3))
+      .toBe('calc((((min(100vw, 75rem) - var(--tedge) * 2) / 16 - 0.5859rem) * 3) + 0.625rem * 2)');
+
+    // var() function for `gap` value.
+    expect(new Columns({ ...allValues, gap: 'var(--tgap)' }).spanCalc(3))
+      .toBe('calc((((min(100vw, 75rem) - 32px * 2) / 16 - (var(--tgap) / 16 * (16 - 1))) * 3) + var(--tgap) * 2)');
+
+    // var() function for `columns` value.
+    expect(new Columns({ ...allValues, columns: 'var(--tcolumns)' }).spanCalc(3))
+      .toBe('calc((((min(100vw, 75rem) - 32px * 2) / var(--tcolumns) - (0.625rem / var(--tcolumns) * (var(--tcolumns) - 1))) * 3) + 0.625rem * 2)');
   });
 
   test('`base` option applied as expected', () => {

--- a/test/sourcemap/column.generated.css
+++ b/test/sourcemap/column.generated.css
@@ -1,12 +1,5 @@
 div {
-	width: calc((((100vw - 0.625rem * 2) / 12 - 1.1458rem) * 3) + 1.25rem * 2);
-	max-width: calc((((90rem - 0.625rem * 2) / 12 - 1.1458rem) * 3) + 1.25rem * 2);
-	margin-left: calc((((100vw - 0.625rem * 2) / 12 - 1.1458rem) * 2) + 1.25rem * 2);
-	margin-right: calc(((100vw - 0.625rem * 2) / 12 - 1.1458rem) + 1.25rem);
-}
-@media (min-width: 90rem) {
-	div {
-		margin-left: calc((((90rem - 0.625rem * 2) / 12 - 1.1458rem) * 2) + 1.25rem * 2);
-		margin-right: calc(((90rem - 0.625rem * 2) / 12 - 1.1458rem) + 1.25rem);
-	}
+	width: calc((((min(100vw, 90rem) - 0.625rem * 2) / 12 - 1.1458rem) * 3) + 1.25rem * 2);
+	margin-left: calc((((min(100vw, 90rem) - 0.625rem * 2) / 12 - 1.1458rem) * 2) + 1.25rem * 2);
+	margin-right: calc(((min(100vw, 90rem) - 0.625rem * 2) / 12 - 1.1458rem) + 1.25rem);
 }

--- a/test/sourcemap/function-span.css
+++ b/test/sourcemap/function-span.css
@@ -1,4 +1,3 @@
 div {
 	width: tidy-span(2);
-	max-width: tidy-span-full(2);
 }

--- a/test/sourcemap/function-span.generated.css
+++ b/test/sourcemap/function-span.generated.css
@@ -1,4 +1,3 @@
 div {
 	width: calc((((100vw - 0.625rem * 2) / 12 - 1.1458rem) * 2) + 1.25rem);
-	max-width: calc((((90rem - 0.625rem * 2) / 12 - 1.1458rem) * 2) + 1.25rem);
 }

--- a/test/sourcemap/function-span.generated.css
+++ b/test/sourcemap/function-span.generated.css
@@ -1,3 +1,3 @@
 div {
-	width: calc((((100vw - 0.625rem * 2) / 12 - 1.1458rem) * 2) + 1.25rem);
+	width: calc((((min(100vw, 90rem) - 0.625rem * 2) / 12 - 1.1458rem) * 2) + 1.25rem);
 }

--- a/test/sourcemap/offset-left.generated.css
+++ b/test/sourcemap/offset-left.generated.css
@@ -1,8 +1,3 @@
 div {
-	margin-left: calc(((100vw - 0.625rem * 2) / 12 - 1.1458rem) + 1.25rem);
-}
-@media (min-width: 90rem) {
-	div {
-		margin-left: calc(((90rem - 0.625rem * 2) / 12 - 1.1458rem) + 1.25rem);
-	}
+	margin-left: calc(((min(100vw, 90rem) - 0.625rem * 2) / 12 - 1.1458rem) + 1.25rem);
 }

--- a/test/sourcemap/offset.generated.css
+++ b/test/sourcemap/offset.generated.css
@@ -1,10 +1,4 @@
 div {
-	margin-left: calc((((100vw - 0.625rem * 2) / 12 - 1.1458rem) * 3) + 1.25rem * 3);
-	margin-right: calc((((100vw - 0.625rem * 2) / 12 - 1.1458rem) * 4) + 1.25rem * 4);
-}
-@media (min-width: 90rem) {
-	div {
-		margin-left: calc((((90rem - 0.625rem * 2) / 12 - 1.1458rem) * 3) + 1.25rem * 3);
-		margin-right: calc((((90rem - 0.625rem * 2) / 12 - 1.1458rem) * 4) + 1.25rem * 4);
-	}
+	margin-left: calc((((min(100vw, 90rem) - 0.625rem * 2) / 12 - 1.1458rem) * 3) + 1.25rem * 3);
+	margin-right: calc((((min(100vw, 90rem) - 0.625rem * 2) / 12 - 1.1458rem) * 4) + 1.25rem * 4);
 }

--- a/test/sourcemap/sourcemap.js
+++ b/test/sourcemap/sourcemap.js
@@ -92,10 +92,10 @@ module.exports = [
         'function-span.css',
       ],
       names: [],
-      mappings: 'AAAA;CACC,kFAAmB;CACnB,sFAA4B;AAC7B',
+      mappings: 'AAAA;CACC,kFAAmB;AACpB',
       file: 'function-span.generated.css',
       sourcesContent: [
-        'div {\n\twidth: tidy-span(2);\n\tmax-width: tidy-span-full(2);\n}\n',
+        'div {\n\twidth: tidy-span(2);\n}\n',
       ],
     },
     fixtures: {

--- a/test/tidy-function.test.js
+++ b/test/tidy-function.test.js
@@ -5,8 +5,11 @@ const { FUNCTION_REGEX } = require('../tidy-function');
 
 /**
  * Replace `tidy-[span|offset]()` and `tidy-[span|offset]-full()` functions.
+ *
+ * @todo Add tests for `tidy-span(tidy-var(columns))`.
  */
 describe('The `tidy-offset` functions are replaced and their values reflect the expected options', () => {
+  // @todo delete this.
   test(
     'Replaces the `tidy-offset()` function',
     () => run(
@@ -16,6 +19,7 @@ describe('The `tidy-offset` functions are replaced and their values reflect the 
     ),
   );
 
+  // @todo delete this.
   test(
     'Replaces the `tidy-offset-full()` function',
     () => run(
@@ -52,6 +56,7 @@ describe('The `tidy-offset` functions are replaced and their values reflect the 
     ),
   );
 
+  // @todo delete this.
   test(
     'Maintains `tidy-offset` input as a /* comment */',
     () => run(
@@ -61,6 +66,7 @@ describe('The `tidy-offset` functions are replaced and their values reflect the 
     ),
   );
 
+  // @todo delete this.
   test(
     'Maintains `tidy-offset-full` input as a /* comment */',
     () => run(
@@ -84,12 +90,23 @@ describe('The `tidy-span()` functions are replaced and their values reflect the 
   test(
     'Replaces the `tidy-span()` function',
     () => run(
-      'div { width: tidy-span(1); }',
-      'div { width: calc((min(100vw, 90rem) - 0.625rem * 2) / 12 - 1.1458rem); }',
+      'div { width: tidy-span(tidy-var(columns)); }',
+      'div { width: calc((((min(100vw, 90rem) - 0.625rem * 2) / 12 - 1.1458rem) * 12) + 1.25rem * 11); }',
       typical,
     ),
   );
 
+  // @todo Make this pass.
+  test.skip(
+    'Replaces the `tidy-span()` function',
+    () => run(
+      'div { width: tidy-span(tidy-var(columns)); }',
+      'div { width: calc((((min(100vw, 90rem) - 0.625rem * 2) / var(--tcol) - (1.25rem * var(--tcol) - (var(--tcol) - 1))) * var(--tcol)) + 1.25rem * (var(--tcol) - 1)); }',
+      { ...typical, columns: 'var(--tcol)' },
+    ),
+  );
+
+  // @todo delete this.
   test(
     'Replaces the `tidy-span-full()` function',
     () => run(

--- a/test/tidy-function.test.js
+++ b/test/tidy-function.test.js
@@ -5,8 +5,6 @@ const { FUNCTION_REGEX } = require('../tidy-function');
 
 /**
  * Replace `tidy-[span|offset]()` functions.
- *
- * @todo Add tests for `tidy-span(tidy-var(columns))`.
  */
 describe('The `tidy-offset` functions are replaced and their values reflect the expected options', () => {
   test(

--- a/test/tidy-function.test.js
+++ b/test/tidy-function.test.js
@@ -4,31 +4,11 @@ const { typical } = require('./sharedConfigs');
 const { FUNCTION_REGEX } = require('../tidy-function');
 
 /**
- * Replace `tidy-[span|offset]()` and `tidy-[span|offset]-full()` functions.
+ * Replace `tidy-[span|offset]()` functions.
  *
  * @todo Add tests for `tidy-span(tidy-var(columns))`.
  */
 describe('The `tidy-offset` functions are replaced and their values reflect the expected options', () => {
-  // @todo delete this.
-  test(
-    'Replaces the `tidy-offset()` function',
-    () => run(
-      'div { margin-left: tidy-offset(1); }',
-      'div { margin-left: calc(((min(100vw, 90rem) - 0.625rem * 2) / 12 - 1.1458rem) + 1.25rem); }',
-      typical,
-    ),
-  );
-
-  // @todo delete this.
-  test(
-    'Replaces the `tidy-offset-full()` function',
-    () => run(
-      'div { margin-left: tidy-offset-full(1); }',
-      'div { margin-left: calc(((min(100vw, 90rem) - 0.625rem * 2) / 12 - 1.1458rem) + 1.25rem); }',
-      typical,
-    ),
-  );
-
   test(
     'Replaces the `tidy-offset()` function when inside a `calc()`` function',
     () => run(
@@ -56,22 +36,11 @@ describe('The `tidy-offset` functions are replaced and their values reflect the 
     ),
   );
 
-  // @todo delete this.
   test(
     'Maintains `tidy-offset` input as a /* comment */',
     () => run(
       'div { margin-left: tidy-offset(1); }',
       'div { /* margin-left: tidy-offset(1) */ margin-left: calc(((min(100vw, 90rem) - 0.625rem * 2) / 12 - 1.1458rem) + 1.25rem); }',
-      { ...typical, debug: true },
-    ),
-  );
-
-  // @todo delete this.
-  test(
-    'Maintains `tidy-offset-full` input as a /* comment */',
-    () => run(
-      'div { margin-left: tidy-offset-full(1); }',
-      'div { /* margin-left: tidy-offset-full(1) */ margin-left: calc(((min(100vw, 90rem) - 0.625rem * 2) / 12 - 1.1458rem) + 1.25rem); }',
       { ...typical, debug: true },
     ),
   );
@@ -105,16 +74,6 @@ describe('The `tidy-span()` functions are replaced and their values reflect the 
       { ...typical, columns: 'var(--tcol)' },
     ),
   );
-
-  // @todo delete this.
-  test(
-    'Replaces the `tidy-span-full()` function',
-    () => run(
-      'div { max-width: tidy-span-full(1); }',
-      'div { max-width: calc((min(100vw, 90rem) - 0.625rem * 2) / 12 - 1.1458rem); }',
-      typical,
-    ),
-  );
 });
 
 /**
@@ -124,23 +83,11 @@ describe('Pattern to match `tidy-*` functions in declaration values', () => {
   test.each([
     [
       'tidy-span(3)',
-      ['tidy-span(3)', 'span', null, '3'],
+      ['tidy-span(3)', 'span', '3'],
     ],
     [
       'tidy-offset(2)',
-      ['tidy-offset(2)', 'offset', null, '2'],
-    ],
-    [
-      'tidy-span-full(1)',
-      ['tidy-span-full(1)', 'span', '-full', '1'],
-    ],
-    [
-      'tidy-offset-full(4)',
-      ['tidy-offset-full(4)', 'offset', '-full', '4'],
-    ],
-    [
-      'calc(tidy-span-full(1) + 20px)',
-      ['tidy-span-full(1)', 'span', '-full', '1'],
+      ['tidy-offset(2)', 'offset', '2'],
     ],
   ])(
     'Matches %s',

--- a/test/tidy-property.test.js
+++ b/test/tidy-property.test.js
@@ -111,7 +111,7 @@ describe('Pattern to match the `tidy-offset-*` property', () => {
     'tidy-span',
     'tidy-offset',
     'tidy-column',
-    'tidy-offset-full(6)',
+    'tidy-offset(6)',
   ])(
     'Ignores %s',
     (input) => {

--- a/test/tidy-var.test.js
+++ b/test/tidy-var.test.js
@@ -17,6 +17,15 @@ describe('The `tidy-var()` function is replaced with the expected option value',
   );
 
   test(
+    'Replaces `tidy-var()` with var() function',
+    () => run(
+      'div { margin-left: tidy-var(gap); }',
+      'div { margin-left: var(--tgap); }',
+      { ...typical, gap: 'var(--tgap)' },
+    ),
+  );
+
+  test(
     'Replaces a multiple instances of `tidy-var()` in a declaration',
     () => run(
       'div { padding: 0 tidy-var(edge) 0 tidy-var(gap); }',

--- a/tidy-function.js
+++ b/tidy-function.js
@@ -8,10 +8,10 @@ const hasComment = require('./lib/hasComment');
  *
  * @type {RegExp}
  */
-const FUNCTION_REGEX = /tidy-(span|offset)(-full)?\(([\d.-]+)\)/;
+const FUNCTION_REGEX = /tidy-(span|offset)\(([\d.-]+)\)/;
 
 /**
- * Replace `tidy-[span|offset]()` and `tidy-[span|offset]-full()` functions.
+ * Replace `tidy-[span|offset]()` functions.
  *
  * @see https://github.com/goodguyry/postcss-tidy-columns#span-function
  * @see https://github.com/goodguyry/postcss-tidy-columns#offset-function
@@ -41,12 +41,11 @@ function tidyFunction(declaration, tidy) {
       columns.suppressCalc = isNested;
 
       /**
-       * match:    The full function expression.
-       * slug:     One of either `span` or `offset`.
-       * modifier: One of either `undefined` or `-full`.
-       * value:    The function's argument.
+       * match: The full function expression.
+       * slug:  One of either `span` or `offset`.
+       * value: The function's argument.
        */
-      const [match, slug, modifier, value] = tidyFunctionMatch.match(FUNCTION_REGEX);
+      const [match, slug, value] = tidyFunctionMatch.match(FUNCTION_REGEX);
 
       /**
        * Get the span or offset `calc()` value(s).
@@ -56,11 +55,7 @@ function tidyFunction(declaration, tidy) {
         ? columns.spanCalc(value)
         : columns.offsetCalc(value);
 
-      return ('-full' === modifier)
-        // tidy-[span|offset]-full()
-        ? acc.replace(match, calcValue)
-        // tidy-[span|offset] ()
-        : acc.replace(match, calcValue);
+      return acc.replace(match, calcValue);
     }, declaration.value);
 
     // Save the original declaration in a comment for debugging.


### PR DESCRIPTION
* Cleans up some tests throughout
* Refactors Columns for clarity
* Removes references to `tidy-span-full()` and `tidy-offset-full()`
* Removes code related to the now-unused full-width media query
* Adds support for disabling an option by setting it to `false`