### PR TITLE
Reinstates support for `tidy-var` as the value for `tidy-span`

### DIFF
--- a/TidyColumns.js
+++ b/TidyColumns.js
@@ -141,8 +141,8 @@ class TidyColumns {
   /**
    * Builds the calc() function.
    *
-   * @param {Number} colSpan The number of columns to span.
-   * @param {Number} gapSpan The number of gaps to span.
+   * @param {Number|String} colSpan The number of columns to span.
+   * @param {Number|String} gapSpan The number of gaps to span.
    * @return {String}
    */
   buildCalcFunction(colSpan, gapSpan) {
@@ -180,6 +180,11 @@ class TidyColumns {
    * @return {String}
    */
   spanCalc(colSpan) {
+    // Assume `colSpan` is a var() function if it can't be parsed as a Number.
+    if (Number.isNaN(Number(colSpan))) {
+      return this.buildCalcFunction(colSpan, `(${colSpan} - 1)`);
+    }
+
     const columnSpan = parseFloat(colSpan, 10);
 
     /**
@@ -195,7 +200,7 @@ class TidyColumns {
   /**
    * Creates the offset `calc()` function declaration for each base value.
    *
-   * @param {String|Number} colSpan The number of columns to offset.
+   * @param {Number} colSpan The number of columns to offset.
    * @return {String}
    */
   offsetCalc(colSpan) {

--- a/__test/src/tidy-function.test.js
+++ b/__test/src/tidy-function.test.js
@@ -68,8 +68,8 @@ describe('The `tidy-span()` functions are replaced and their values reflect the 
     'Replaces the `tidy-span()` function',
     () => run(
       'div { width: tidy-span(tidy-var(columns)); }',
-      'div { width: calc((((min(100vw, 90rem) - 0.625rem * 2) / var(--tcol) - (1.25rem / var(--tcol) * (var(--tcol) - 1))) * var(--tcol)) + 1.25rem * (var(--tcol) - 1)); }',
-      { ...typical, columns: 'var(--tcol)' },
+      'div { width: calc((((min(100vw, 90rem) - 0.625rem * 2) / var(--tc-col) - (1.25rem / var(--tc-col) * (var(--tc-col) - 1))) * var(--tc-col)) + 1.25rem * (var(--tc-col) - 1)); }',
+      { ...typical, columns: 'var(--tc-col)' },
     ),
   );
 });

--- a/__test/src/tidy-function.test.js
+++ b/__test/src/tidy-function.test.js
@@ -64,11 +64,11 @@ describe('The `tidy-span()` functions are replaced and their values reflect the 
   );
 
   // @todo Make this pass.
-  test.skip(
+  test(
     'Replaces the `tidy-span()` function',
     () => run(
       'div { width: tidy-span(tidy-var(columns)); }',
-      'div { width: calc((((min(100vw, 90rem) - 0.625rem * 2) / var(--tcol) - (1.25rem * var(--tcol) - (var(--tcol) - 1))) * var(--tcol)) + 1.25rem * (var(--tcol) - 1)); }',
+      'div { width: calc((((min(100vw, 90rem) - 0.625rem * 2) / var(--tcol) - (1.25rem / var(--tcol) * (var(--tcol) - 1))) * var(--tcol)) + 1.25rem * (var(--tcol) - 1)); }',
       { ...typical, columns: 'var(--tcol)' },
     ),
   );

--- a/src/tidy-function.js
+++ b/src/tidy-function.js
@@ -5,7 +5,7 @@ const cleanClone = require('./lib/cleanClone');
  *
  * @type {RegExp}
  */
-const FUNCTION_PATTERN = /tidy-(span|offset)\(([\d.-]+|var\(--\w*\))\)/;
+const FUNCTION_PATTERN = /tidy-(span|offset)\(([\d.-]+|var\(--[\w-]*\))\)/;
 
 /**
  * Extracts tidy-span|offset functions and note whether they're nested within a CSS function.

--- a/src/tidy-function.js
+++ b/src/tidy-function.js
@@ -5,7 +5,7 @@ const cleanClone = require('./lib/cleanClone');
  *
  * @type {RegExp}
  */
-const FUNCTION_PATTERN = /tidy-(span|offset)\(([\d.-]+)\)/;
+const FUNCTION_PATTERN = /tidy-(span|offset)\(([\d.-]+|var\(--\w*\))\)/;
 
 /**
  * Extracts tidy-span|offset functions and note whether they're nested within a CSS function.


### PR DESCRIPTION
Originally added via #27 and #32, there was a regression after the plugin rewrite.